### PR TITLE
Fix issues in 2016 puzzles

### DIFF
--- a/src/AdventOfCode/Puzzles/Y2016/Day01.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day01.cs
@@ -39,7 +39,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
         public int BlocksToEasterBunnyHQIgnoringDuplicates { get; private set; }
 
         /// <summary>
-        /// Calculate the distance, in blocks, following the specified instructions are.
+        /// Calculate the distance, in blocks, by following the specified instructions.
         /// </summary>
         /// <param name="input">The instructions to follow.</param>
         /// <param name="ignoreDuplicates">Whether to ignore duplicate locations.</param>

--- a/src/AdventOfCode/Puzzles/Y2016/Day10.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day10.cs
@@ -78,6 +78,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
             ProductOfMicrochipsInBins012 = result.Item2;
 
             Console.WriteLine($"The number of the bot that compares value-61 and value-17 microchips is {BotThatCompares61And17Microchips:N0}.");
+            Console.WriteLine($"The product of the microchips in output bins 0, 1 and 2 is {ProductOfMicrochipsInBins012:N0}.");
 
             return 0;
         }


### PR DESCRIPTION
  1. Fix missing answer to day 10 part 2 when run from the console.
  2. Fix incorrect grammar in XML comment in day 1.