### PR TITLE
Refactor integer parsing

### DIFF
--- a/src/AdventOfCode/Puzzles/Y2016/Day01.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day01.cs
@@ -5,7 +5,6 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
 {
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
 
     /// <summary>
     /// A class representing the puzzle for <c>http://adventofcode.com/2016/day/1</c>. This class cannot be inherited.
@@ -131,7 +130,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
                 var instruction = new Instruction()
                 {
                     Direction = rawInstruction[0] == 'L' ? Direction.Left : Direction.Right,
-                    Distance = int.Parse(rawInstruction.Substring(1), CultureInfo.InvariantCulture),
+                    Distance = ParseInt32(rawInstruction.Substring(1)),
                 };
 
                 result.Add(instruction);

--- a/src/AdventOfCode/Puzzles/Y2016/Day03.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day03.cs
@@ -5,7 +5,6 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
 {
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
     using System.Linq;
 
     /// <summary>
@@ -84,9 +83,9 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
             {
                 string[] components = dimension.Trim().Split(Arrays.Space, StringSplitOptions.RemoveEmptyEntries);
 
-                int a = int.Parse(components[0], CultureInfo.InvariantCulture);
-                int b = int.Parse(components[1], CultureInfo.InvariantCulture);
-                int c = int.Parse(components[2], CultureInfo.InvariantCulture);
+                int a = ParseInt32(components[0]);
+                int b = ParseInt32(components[1]);
+                int c = ParseInt32(components[2]);
 
                 result.Add(Tuple.Create(a, b, c));
             }

--- a/src/AdventOfCode/Puzzles/Y2016/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day04.cs
@@ -5,7 +5,6 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
 {
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
     using System.Linq;
     using System.Text;
 
@@ -70,7 +69,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
 
                 if (string.Equals("northpole object storage", decryptedName, StringComparison.OrdinalIgnoreCase))
                 {
-                    sectorId = int.Parse(sectorIdString, CultureInfo.InvariantCulture);
+                    sectorId = ParseInt32(sectorIdString);
                 }
             }
 
@@ -95,7 +94,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
 
                 if (IsRoomReal(name, out encryptedName, out sectorIdString))
                 {
-                    sum += int.Parse(sectorIdString, CultureInfo.InvariantCulture);
+                    sum += ParseInt32(sectorIdString);
                 }
             }
 
@@ -132,7 +131,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
 
             if (IsRoomReal(name, out encryptedName, out sectorId))
             {
-                int sectorIdValue = int.Parse(sectorId, CultureInfo.InvariantCulture);
+                int sectorIdValue = ParseInt32(sectorId);
 
                 foreach (char ch in encryptedName)
                 {

--- a/src/AdventOfCode/Puzzles/Y2016/Day08.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day08.cs
@@ -5,7 +5,6 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
 {
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
     using System.Linq;
 
     /// <summary>
@@ -217,15 +216,15 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
             {
                 case "rect":
                     split = split[1].Split(Arrays.X, StringSplitOptions.None);
-                    result.A = int.Parse(split[0], CultureInfo.InvariantCulture);
-                    result.B = int.Parse(split[1], CultureInfo.InvariantCulture);
+                    result.A = ParseInt32(split[0]);
+                    result.B = ParseInt32(split[1]);
                     break;
 
                 case "rotate":
                     result.IsRotation = true;
                     result.IsColumn = string.Equals(split[1], "column", StringComparison.Ordinal);
-                    result.A = int.Parse(split[2].Split(Arrays.EqualsSign, StringSplitOptions.None)[1]);
-                    result.B = int.Parse(split[4], CultureInfo.InvariantCulture);
+                    result.A = ParseInt32(split[2].Split(Arrays.EqualsSign, StringSplitOptions.None)[1]);
+                    result.B = ParseInt32(split[4]);
                     break;
 
                 default:

--- a/src/AdventOfCode/Puzzles/Y2016/Day09.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day09.cs
@@ -4,7 +4,6 @@
 namespace MartinCostello.AdventOfCode.Puzzles.Y2016
 {
     using System;
-    using System.Globalization;
     using System.Text;
 
     /// <summary>
@@ -83,8 +82,8 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
 
                         string[] split = marker.ToString().Split(Arrays.X, StringSplitOptions.None);
 
-                        repeatLength = int.Parse(split[0], CultureInfo.InvariantCulture);
-                        repeatCount = int.Parse(split[1], CultureInfo.InvariantCulture);
+                        repeatLength = ParseInt32(split[0]);
+                        repeatCount = ParseInt32(split[1]);
 
                         isInRepeat = true;
                         marker.Clear();

--- a/src/AdventOfCode/Puzzles/Y2016/Day10.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day10.cs
@@ -5,7 +5,6 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
 {
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
     using System.Linq;
 
     /// <summary>
@@ -273,20 +272,20 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
 
                 if (string.Equals(split[0], "value", StringComparison.Ordinal))
                 {
-                    int chipValue = int.Parse(split[1], CultureInfo.InvariantCulture);
-                    int botNumber = int.Parse(split[5], CultureInfo.InvariantCulture);
+                    int chipValue = ParseInt32(split[1]);
+                    int botNumber = ParseInt32(split[5]);
 
                     GetBot(botNumber).Accept(new Chip(chipValue));
                 }
                 else
                 {
                     bool isHighBot = string.Equals("bot", split[10], StringComparison.Ordinal);
-                    int highValue = int.Parse(split[11], CultureInfo.InvariantCulture);
+                    int highValue = ParseInt32(split[11]);
 
                     bool isLowBot = string.Equals("bot", split[5], StringComparison.Ordinal);
-                    int lowValue = int.Parse(split[6], CultureInfo.InvariantCulture);
+                    int lowValue = ParseInt32(split[6]);
 
-                    int botNumber = int.Parse(split[1], CultureInfo.InvariantCulture);
+                    int botNumber = ParseInt32(split[1]);
 
                     Bot bot = GetBot(botNumber);
 

--- a/src/AdventOfCode/Puzzles/Y2016/Day12.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day12.cs
@@ -81,7 +81,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
 
                         if (value != 0)
                         {
-                            i += int.Parse(split[2], CultureInfo.InvariantCulture) - 1;
+                            i += ParseInt32(split[2]) - 1;
                         }
 
                         break;


### PR DESCRIPTION
Use ```Puzzle``` base class methods to parse integers instead of ```int.Parse()``` to remove the need to specify the ```IFormatProvider``` for all the calls.