### PR TITLE
Add "verbose" mode

### DIFF
--- a/src/AdventOfCode/IPuzzle.cs
+++ b/src/AdventOfCode/IPuzzle.cs
@@ -9,6 +9,11 @@ namespace MartinCostello.AdventOfCode
     public interface IPuzzle
     {
         /// <summary>
+        /// Gets or sets a value indicating whether the puzzle should be run verbosely.
+        /// </summary>
+        bool Verbose { get; set; }
+
+        /// <summary>
         /// Solves the puzzle given the specified input.
         /// </summary>
         /// <param name="args">The input arguments to the puzzle.</param>

--- a/src/AdventOfCode/Program.cs
+++ b/src/AdventOfCode/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode
@@ -54,7 +54,7 @@ namespace MartinCostello.AdventOfCode
 
             args = args.Skip(1).ToArray();
 
-            return SolvePuzzle(type, year, day, args);
+            return SolvePuzzle(type, year, day, args, verbose: true);
         }
 
         /// <summary>
@@ -64,12 +64,14 @@ namespace MartinCostello.AdventOfCode
         /// <param name="year">The year associated with the puzzle.</param>
         /// <param name="day">The day associated with the puzzle.</param>
         /// <param name="args">The arguments to pass to the puzzle.</param>
+        /// <param name="verbose">Whether the puzzle should be run verbosely.</param>
         /// <returns>
         /// The value returned by <see cref="IPuzzle.Solve"/>.
         /// </returns>
-        internal static int SolvePuzzle(Type type, int year, int day, string[] args)
+        internal static int SolvePuzzle(Type type, int year, int day, string[] args, bool verbose = false)
         {
             IPuzzle puzzle = Activator.CreateInstance(type) as IPuzzle;
+            puzzle.Verbose = verbose;
 
             Console.WriteLine();
             Console.WriteLine("Advent of Code {0} - Day {1}", year, day);

--- a/src/AdventOfCode/Puzzle.cs
+++ b/src/AdventOfCode/Puzzle.cs
@@ -5,7 +5,6 @@ namespace MartinCostello.AdventOfCode
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Globalization;
     using System.IO;
     using System.Reflection;
@@ -15,6 +14,11 @@ namespace MartinCostello.AdventOfCode
     /// </summary>
     public abstract class Puzzle : IPuzzle
     {
+        /// <summary>
+        /// Gets or sets a value indicating whether the puzzle should be run verbosely.
+        /// </summary>
+        public bool Verbose { get; set; }
+
         /// <summary>
         /// Gets the minimum number of arguments required to solve the puzzle.
         /// </summary>
@@ -68,7 +72,7 @@ namespace MartinCostello.AdventOfCode
         /// <returns>
         /// The parsed value of <paramref name="s"/>.
         /// </returns>
-        protected internal static int ParseInt32(string s, NumberStyles style = NumberStyles.Integer)
+        protected internal static int ParseInt32(ReadOnlySpan<char> s, NumberStyles style = NumberStyles.Integer)
         {
             return int.Parse(s, style, CultureInfo.InvariantCulture);
         }
@@ -85,7 +89,7 @@ namespace MartinCostello.AdventOfCode
         /// <see langword="true"/> if <paramref name="s"/> was parsed
         /// successfully; otherwise <see langword="false"/>.
         /// </returns>
-        protected internal static bool TryParseInt32(string s, out int value)
+        protected internal static bool TryParseInt32(ReadOnlySpan<char> s, out int value)
         {
             return int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
         }
@@ -97,7 +101,7 @@ namespace MartinCostello.AdventOfCode
         /// <returns>
         /// The parsed value of <paramref name="s"/>.
         /// </returns>
-        protected internal static uint ParseUInt32(string s) => uint.Parse(s, CultureInfo.InvariantCulture);
+        protected internal static uint ParseUInt32(ReadOnlySpan<char> s) => uint.Parse(s, NumberStyles.Integer, CultureInfo.InvariantCulture);
 
         /// <summary>
         /// Ensures that the specified number of arguments are present.
@@ -111,29 +115,6 @@ namespace MartinCostello.AdventOfCode
         protected static bool EnsureArguments(ICollection<string> args, int minimumLength)
         {
             return args.Count >= minimumLength;
-        }
-
-        /// <summary>
-        /// Writes a line to the console.
-        /// </summary>
-        /// <param name="format">The format string to use.</param>
-        /// <param name="arg0">The first argument.</param>
-        [Conditional("BENCHMARKS")]
-        protected static void WriteLine(string format, object arg0)
-        {
-            Console.WriteLine(format, arg0);
-        }
-
-        /// <summary>
-        /// Writes a line to the console.
-        /// </summary>
-        /// <param name="format">The format string to use.</param>
-        /// <param name="arg0">The first argument.</param>
-        /// <param name="arg1">The second argument.</param>
-        [Conditional("BENCHMARKS")]
-        protected static void WriteLine(string format, object arg0, object arg1)
-        {
-            Console.WriteLine(format, arg0, arg1);
         }
 
         /// <summary>
@@ -162,7 +143,7 @@ namespace MartinCostello.AdventOfCode
 
             using (Stream stream = ReadResource())
             {
-                using (TextReader reader = new StreamReader(stream))
+                using (var reader = new StreamReader(stream))
                 {
                     string value = null;
 
@@ -186,7 +167,7 @@ namespace MartinCostello.AdventOfCode
         {
             using (Stream stream = ReadResource())
             {
-                using (TextReader reader = new StreamReader(stream))
+                using (var reader = new StreamReader(stream))
                 {
                     return reader.ReadToEnd();
                 }

--- a/src/AdventOfCode/Puzzles/Y2015/Day01.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day01.cs
@@ -75,8 +75,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
             FinalFloor = result.Item1;
             FirstBasementInstruction = result.Item2;
 
-            WriteLine("Santa should go to floor {0}.", FinalFloor);
-            WriteLine("Santa first enters the basement after following instruction {0:N0}.", FirstBasementInstruction);
+            if (Verbose)
+            {
+                Console.WriteLine("Santa should go to floor {0}.", FinalFloor);
+                Console.WriteLine("Santa first enters the basement after following instruction {0:N0}.", FirstBasementInstruction);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2015/Day02.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day02.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2015
@@ -53,11 +53,14 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
             TotalAreaOfPaper = result.Item1;
             TotalLengthOfRibbon = result.Item2;
 
-            Console.WriteLine(
-                "The elves should order {0:N0} square feet of wrapping paper.{1}They also need {2:N0} feet of ribbon.",
-                TotalAreaOfPaper,
-                Environment.NewLine,
-                TotalLengthOfRibbon);
+            if (Verbose)
+            {
+                Console.WriteLine(
+                    "The elves should order {0:N0} square feet of wrapping paper.{1}They also need {2:N0} feet of ribbon.",
+                    TotalAreaOfPaper,
+                    Environment.NewLine,
+                    TotalLengthOfRibbon);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2015/Day03.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day03.cs
@@ -85,13 +85,16 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
             HousesWithPresentsFromSanta = GetUniqueHousesVisitedBySanta(instructions);
             HousesWithPresentsFromSantaAndRoboSanta = GetUniqueHousesVisitedBySantaAndRoboSanta(instructions);
 
-            Console.WriteLine(
-                "In 2015, Santa delivered presents to {0:N0} houses.",
-                HousesWithPresentsFromSanta);
+            if (Verbose)
+            {
+                Console.WriteLine(
+                    "In 2015, Santa delivered presents to {0:N0} houses.",
+                    HousesWithPresentsFromSanta);
 
-            Console.WriteLine(
-                "In 2016, Santa and Robo-Santa delivered presents to {0:N0} houses.",
-                HousesWithPresentsFromSantaAndRoboSanta);
+                Console.WriteLine(
+                    "In 2016, Santa and Robo-Santa delivered presents to {0:N0} houses.",
+                    HousesWithPresentsFromSantaAndRoboSanta);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2015/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day04.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2015
@@ -116,10 +116,13 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
 
             LowestZeroHash = GetLowestPositiveNumberWithStartingZeroes(secretKey, zeroes);
 
-            Console.WriteLine(
-                "The lowest positive number for a hash starting with {0} zeroes is {1:N0}.",
-                zeroes,
-                LowestZeroHash);
+            if (Verbose)
+            {
+                Console.WriteLine(
+                    "The lowest positive number for a hash starting with {0} zeroes is {1:N0}.",
+                    zeroes,
+                    LowestZeroHash);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2015/Day05.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day05.cs
@@ -185,7 +185,10 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
 
             NiceStringCount = count;
 
-            Console.WriteLine("{0:N0} strings are nice using version {1} of the rules.", NiceStringCount, version);
+            if (Verbose)
+            {
+                Console.WriteLine("{0:N0} strings are nice using version {1} of the rules.", NiceStringCount, version);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2015/Day06.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day06.cs
@@ -67,7 +67,10 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                 }
             }
 
-            Console.WriteLine("Processing instructions using set {0}...", version);
+            if (Verbose)
+            {
+                Console.WriteLine("Processing instructions using set {0}...", version);
+            }
 
             var grid = new LightGrid(1000, 1000);
 
@@ -79,12 +82,20 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
             if (version == 1)
             {
                 LightsIlluminated = grid.Count;
-                Console.WriteLine("{0:N0} lights are illuminated.", LightsIlluminated);
+
+                if (Verbose)
+                {
+                    Console.WriteLine("{0:N0} lights are illuminated.", LightsIlluminated);
+                }
             }
             else
             {
                 TotalBrightness = grid.Brightness;
-                Console.WriteLine("The total brightness of the grid is {0:N0}.", TotalBrightness);
+
+                if (Verbose)
+                {
+                    Console.WriteLine("The total brightness of the grid is {0:N0}.", TotalBrightness);
+                }
             }
 
             return 0;

--- a/src/AdventOfCode/Puzzles/Y2015/Day07.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day07.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2015
@@ -60,10 +60,8 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                     if (words.Length == 1)
                     {
                         // "123 -> x" or " -> "lx -> a"
-                        ushort value;
-
                         // Is the instruction a value or a previously solved value?
-                        if (ushort.TryParse(firstOperand, out value) || result.TryGetValue(firstOperand, out value))
+                        if (ushort.TryParse(firstOperand, out ushort value) || result.TryGetValue(firstOperand, out value))
                         {
                             result[wireId] = value;
                         }
@@ -73,10 +71,8 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                         // "NOT e -> f" or "NOT 1 -> g"
                         secondOperand = words.ElementAtOrDefault(1);
 
-                        ushort value;
-
                         // Is the second operand a value or a previously solved value?
-                        if (ushort.TryParse(secondOperand, out value) ||
+                        if (ushort.TryParse(secondOperand, out ushort value) ||
                             result.TryGetValue(secondOperand, out value))
                         {
                             result[wireId] = (ushort)~value;
@@ -86,12 +82,9 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                     {
                         secondOperand = words.ElementAtOrDefault(2);
 
-                        ushort firstValue;
-                        ushort secondValue;
-
                         // Are both operands a value or a previously solved value?
-                        if ((ushort.TryParse(firstOperand, out firstValue) || result.TryGetValue(firstOperand, out firstValue)) &&
-                            (ushort.TryParse(secondOperand, out secondValue) || result.TryGetValue(secondOperand, out secondValue)))
+                        if ((ushort.TryParse(firstOperand, out ushort firstValue) || result.TryGetValue(firstOperand, out firstValue)) &&
+                            (ushort.TryParse(secondOperand, out ushort secondValue) || result.TryGetValue(secondOperand, out secondValue)))
                         {
                             string operation = words.ElementAtOrDefault(1);
                             solvedValue = TrySolveValueForOperation(operation, firstValue, secondValue);
@@ -119,7 +112,10 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
 
             FirstSignal = values["a"];
 
-            Console.WriteLine("The signal for wire a is {0:N0}.", FirstSignal);
+            if (Verbose)
+            {
+                Console.WriteLine("The signal for wire a is {0:N0}.", FirstSignal);
+            }
 
             // Replace the input value for b with the value for a, then re-calculate
             int indexForB = instructions.IndexOf("44430 -> b");
@@ -129,7 +125,10 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
 
             SecondSignal = values["a"];
 
-            Console.WriteLine("The new signal for wire a is {0:N0}.", SecondSignal);
+            if (Verbose)
+            {
+                Console.WriteLine("The new signal for wire a is {0:N0}.", SecondSignal);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2015/Day08.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day08.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2015
@@ -142,13 +142,19 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
             int countInMemory = GetLiteralCharacterCount(input);
             int countEncoded = GetEncodedCharacterCount(input);
 
-            Console.WriteLine(
-                "The number of characters of code for string literals minus the number of characters in memory for the values of the strings is {0:N0}.",
-                FirstSolution = countForCode - countInMemory);
+            FirstSolution = countForCode - countInMemory;
+            SecondSolution = countEncoded - countForCode;
 
-            Console.WriteLine(
-                "The total number of characters to represent the newly encoded strings minus the number of characters of code in each original string literal is {0:N0}.",
-                SecondSolution = countEncoded - countForCode);
+            if (Verbose)
+            {
+                Console.WriteLine(
+                    "The number of characters of code for string literals minus the number of characters in memory for the values of the strings is {0:N0}.",
+                    FirstSolution);
+
+                Console.WriteLine(
+                    "The total number of characters to represent the newly encoded strings minus the number of characters of code in each original string literal is {0:N0}.",
+                    SecondSolution);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2015/Day09.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day09.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2015
@@ -121,13 +121,16 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
 
             Solution = GetDistanceBetweenPoints(ReadResourceAsLines(), findLongest);
 
-            if (findLongest)
+            if (Verbose)
             {
-                Console.WriteLine("The distance of the longest route is {0:N0}.", Solution);
-            }
-            else
-            {
-                Console.WriteLine("The distance of the shortest route is {0:N0}.", Solution);
+                if (findLongest)
+                {
+                    Console.WriteLine("The distance of the longest route is {0:N0}.", Solution);
+                }
+                else
+                {
+                    Console.WriteLine("The distance of the shortest route is {0:N0}.", Solution);
+                }
             }
 
             return 0;

--- a/src/AdventOfCode/Puzzles/Y2015/Day10.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day10.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2015
@@ -61,11 +61,16 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                 result = AsLookAndSay(result);
             }
 
-            Console.WriteLine(
-                "The length of the result for input '{0}' after {1:N0} iterations is {2:N0}.",
-                value,
-                iterations,
-                Solution = result.Length);
+            Solution = result.Length;
+
+            if (Verbose)
+            {
+                Console.WriteLine(
+                    "The length of the result for input '{0}' after {1:N0} iterations is {2:N0}.",
+                    value,
+                    iterations,
+                    result.Length);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2015/Day11.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day11.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2015
@@ -86,9 +86,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
 
                 string pair = new string(new[] { first, second });
 
-                IList<int> indexes;
-
-                if (!letterPairs.TryGetValue(pair, out indexes))
+                if (!letterPairs.TryGetValue(pair, out IList<int> indexes))
                 {
                     indexes = letterPairs[pair] = new List<int>();
                 }
@@ -108,7 +106,10 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
             string current = args[0];
             NextPassword = GenerateNextPassword(current);
 
-            Console.WriteLine("Santa's new password should be '{0}'.", NextPassword);
+            if (Verbose)
+            {
+                Console.WriteLine("Santa's new password should be '{0}'.", NextPassword);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2015/Day12.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day12.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2015
@@ -26,11 +26,9 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
         /// <returns>The sum of the tokens in <paramref name="token"/>.</returns>
         internal static long SumIntegerValues(JToken token, string valueToIgnore)
         {
-            JValue value = token as JValue;
-
             long sum = 0;
 
-            if (value != null && value.Type == JTokenType.Integer)
+            if (token is JValue value && value.Type == JTokenType.Integer)
             {
                 sum = (long)value.Value;
             }
@@ -75,7 +73,10 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
 
             Sum = SumIntegerValues(document, keyToIgnore);
 
-            Console.WriteLine("The sum of the integers in the JSON document is {0:N0}.", Sum);
+            if (Verbose)
+            {
+                Console.WriteLine("The sum of the integers in the JSON document is {0:N0}.", Sum);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2015/Day13.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day13.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2015
@@ -63,7 +63,10 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
 
             MaximumTotalChangeInHappiness = GetMaximumTotalChangeInHappiness(potentialHappiness);
 
-            Console.WriteLine("The total change in happiness is {0:N0}.", MaximumTotalChangeInHappiness);
+            if (Verbose)
+            {
+                Console.WriteLine("The total change in happiness is {0:N0}.", MaximumTotalChangeInHappiness);
+            }
 
             // Create a new guest list which is the same as the previous one but with the current user added
             var potentialHappinessWithCurrentUser = new List<string>(potentialHappiness);
@@ -86,7 +89,10 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
 
             MaximumTotalChangeInHappinessWithCurrentUser = GetMaximumTotalChangeInHappiness(potentialHappinessWithCurrentUser);
 
-            Console.WriteLine("The total change in happiness with the current user seated is {0:N0}.", MaximumTotalChangeInHappinessWithCurrentUser);
+            if (Verbose)
+            {
+                Console.WriteLine("The total change in happiness with the current user seated is {0:N0}.", MaximumTotalChangeInHappinessWithCurrentUser);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2015/Day14.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day14.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2015
@@ -97,11 +97,17 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
 
             MaximumReindeerDistance = GetMaximumDistanceOfFastestReindeer(flightData, timeIndex);
 
-            Console.WriteLine("After {0:N0} seconds, the furthest reindeer is {1:N0} km away.", timeIndex, MaximumReindeerDistance);
+            if (Verbose)
+            {
+                Console.WriteLine("After {0:N0} seconds, the furthest reindeer is {1:N0} km away.", timeIndex, MaximumReindeerDistance);
+            }
 
             MaximumReindeerPoints = GetMaximumPointsOfFastestReindeer(flightData, timeIndex);
 
-            Console.WriteLine("After {0:N0} seconds, the reindeer in the lead has {1:N0} points.", timeIndex, MaximumReindeerPoints);
+            if (Verbose)
+            {
+                Console.WriteLine("After {0:N0} seconds, the reindeer in the lead has {1:N0} points.", timeIndex, MaximumReindeerPoints);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2015/Day15.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day15.cs
@@ -85,8 +85,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
             HighestTotalCookieScore = GetHighestTotalCookieScore(ingredients);
             HighestTotalCookieScoreWith500Calories = GetHighestTotalCookieScore(ingredients, 500);
 
-            Console.WriteLine("The highest total cookie score is {0:N0}.", HighestTotalCookieScore);
-            Console.WriteLine("The highest total cookie score for a cookie with 500 calories is {0:N0}.", HighestTotalCookieScoreWith500Calories);
+            if (Verbose)
+            {
+                Console.WriteLine("The highest total cookie score is {0:N0}.", HighestTotalCookieScore);
+                Console.WriteLine("The highest total cookie score for a cookie with 500 calories is {0:N0}.", HighestTotalCookieScoreWith500Calories);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2015/Day16.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day16.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2015
@@ -82,10 +82,13 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
             AuntSueNumber = WhichAuntSueSentTheGift(auntSueMetadata);
             RealAuntSueNumber = WhichAuntSueSentTheGift(auntSueMetadata, compensateForRetroEncabulator: true);
 
-            Console.WriteLine(
-                "The number of the Aunt Sue that got me the gift was originally thought to be {0}, but it was actually {1}.",
-                AuntSueNumber,
-                RealAuntSueNumber);
+            if (Verbose)
+            {
+                Console.WriteLine(
+                    "The number of the Aunt Sue that got me the gift was originally thought to be {0}, but it was actually {1}.",
+                    AuntSueNumber,
+                    RealAuntSueNumber);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2015/Day17.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day17.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2015
@@ -58,16 +58,19 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
             Combinations = combinations.Count;
             CombinationsWithMinimumContainers = combinationsWithLeastContainers.Count();
 
-            Console.WriteLine(
-                "There are {0:N0} combinations of containers that can store {1:0} liters of eggnog.",
-                Combinations,
-                volume);
+            if (Verbose)
+            {
+                Console.WriteLine(
+                    "There are {0:N0} combinations of containers that can store {1:0} liters of eggnog.",
+                    Combinations,
+                    volume);
 
-            Console.WriteLine(
-                "There are {0:N0} combinations of containers that can store {1:0} liters of eggnog using {2} containers.",
-                CombinationsWithMinimumContainers,
-                volume,
-                combinationsWithLeastContainers.Key);
+                Console.WriteLine(
+                    "There are {0:N0} combinations of containers that can store {1:0} liters of eggnog using {2} containers.",
+                    CombinationsWithMinimumContainers,
+                    volume,
+                    combinationsWithLeastContainers.Key);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2015/Day18.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day18.cs
@@ -93,10 +93,13 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                 }
             }
 
-            Console.WriteLine(
-                "There are {0:N0} lights illuminated after {1:N0} steps.",
-                LightsIlluminated,
-                steps);
+            if (Verbose)
+            {
+                Console.WriteLine(
+                    "There are {0:N0} lights illuminated after {1:N0} steps.",
+                    LightsIlluminated,
+                    steps);
+            }
 
             return 0;
         }
@@ -109,9 +112,6 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
         /// <returns>
         /// An <see cref="Array"/> of <see cref="bool"/> containing the new frame.
         /// </returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1814:PreferJaggedArraysOverMultidimensional", MessageId = "0#", Justification = "Easier to visualize.")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1814:PreferJaggedArraysOverMultidimensional", MessageId = "Body", Justification = "Easier to visualize.")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1814:PreferJaggedArraysOverMultidimensional", MessageId = "Return", Justification = "Easier to visualize.")]
         private static bool[,] Animate(bool[,] input, bool areCornerLightsBroken)
         {
             int width = input.GetLength(0);
@@ -198,8 +198,6 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
         /// An <see cref="Array"/> of <see cref="bool"/> representing the light configuration
         /// specified by <paramref name="initialState"/>.
         /// </returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1814:PreferJaggedArraysOverMultidimensional", MessageId = "Body", Justification = "Easier to visualize.")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1814:PreferJaggedArraysOverMultidimensional", MessageId = "Return", Justification = "Easier to visualize.")]
         private static bool[,] ParseInitialState(IList<string> initialState)
         {
             // Assume that the input configuration is a rectangle

--- a/src/AdventOfCode/Puzzles/Y2015/Day19.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day19.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2015
@@ -31,7 +31,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
         /// </returns>
         internal static ICollection<string> GetPossibleMolecules(string molecule, ICollection<string> replacements)
         {
-            List<string> molecules = new List<string>();
+            var molecules = new List<string>();
 
             foreach (string replacement in replacements)
             {
@@ -145,7 +145,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
             if (fabricate)
             {
                 Solution = GetMinimumSteps(molecule, replacements);
-                Console.WriteLine("The target molecule can be made in a minimum of {0:N0} steps.", Solution);
+
+                if (Verbose)
+                {
+                    Console.WriteLine("The target molecule can be made in a minimum of {0:N0} steps.", Solution);
+                }
             }
             else
             {
@@ -153,10 +157,13 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
 
                 Solution = molecules.Count;
 
-                Console.WriteLine(
-                    "{0:N0} distinct molecules can be created from {1:N0} possible replacements.",
-                    Solution,
-                    replacements.Count);
+                if (Verbose)
+                {
+                    Console.WriteLine(
+                        "{0:N0} distinct molecules can be created from {1:N0} possible replacements.",
+                        Solution,
+                        replacements.Count);
+                }
             }
 
             return 0;

--- a/src/AdventOfCode/Puzzles/Y2015/Day20.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day20.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2015
@@ -88,10 +88,13 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
 
             LowestHouseNumber = GetLowestHouseNumber(target, maximumVisits);
 
-            Console.WriteLine(
-                "The first house to receive at least {0:N0} presents is house number {1:N0}.",
-                target,
-                LowestHouseNumber);
+            if (Verbose)
+            {
+                Console.WriteLine(
+                    "The first house to receive at least {0:N0} presents is house number {1:N0}.",
+                    target,
+                    LowestHouseNumber);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2015/Day21.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day21.cs
@@ -129,13 +129,16 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
             MaximumCostToLose = costsToLose.Max();
             MinimumCostToWin = costsToWin.Min();
 
-            Console.WriteLine(
-                "The minimum amount of gold spent for the human to beat the boss is {0:N0}.",
-                MinimumCostToWin);
+            if (Verbose)
+            {
+                Console.WriteLine(
+                    "The minimum amount of gold spent for the human to beat the boss is {0:N0}.",
+                    MinimumCostToWin);
 
-            Console.WriteLine(
-                "The maximum amount of gold spent for the human to lose to the boss is {0:N0}.",
-                MaximumCostToLose);
+                Console.WriteLine(
+                    "The maximum amount of gold spent for the human to lose to the boss is {0:N0}.",
+                    MaximumCostToLose);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2015/Day22.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day22.cs
@@ -31,7 +31,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
             Wizard wizard = new Wizard(spellSelector);
             Boss boss = new Boss();
 
-            Player winner = Fight(wizard, boss, difficulty, (f, a) => { });
+            Player winner = Fight(wizard, boss, difficulty, null);
 
             return Tuple.Create(winner == wizard, wizard.ManaSpent);
         }
@@ -55,9 +55,9 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
 
             do
             {
-                output("-- {0} turn --", new object[] { attacker.Name });
-                output("- {0} has {1} hit points, {2} armor, {3} mana", new object[] { wizard.Name, wizard.HitPoints, wizard.Armor, wizard.Mana });
-                output("- {0} has {1} hit points", new object[] { opponent.Name, opponent.HitPoints });
+                output?.Invoke("-- {0} turn --", new object[] { attacker.Name });
+                output?.Invoke("- {0} has {1} hit points, {2} armor, {3} mana", new object[] { wizard.Name, wizard.HitPoints, wizard.Armor, wizard.Mana });
+                output?.Invoke("- {0} has {1} hit points", new object[] { opponent.Name, opponent.HitPoints });
 
                 if (isHardDifficulty && attacker == wizard)
                 {
@@ -80,7 +80,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                 attacker = defender;
                 defender = player;
 
-                output(string.Empty, Array.Empty<object>());
+                output?.Invoke(string.Empty, Array.Empty<object>());
             }
             while (wizard.HitPoints > 0 && opponent.HitPoints > 0);
 
@@ -106,10 +106,13 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                 .Where((p) => p.Item1)
                 .Min((p) => p.Item2);
 
-            Console.WriteLine(
-                "The minimum amount of mana that can be spent to win on {0} difficulty is {1:N0}.",
-                difficulty,
-                MinimumCostToWin);
+            if (Verbose)
+            {
+                Console.WriteLine(
+                    "The minimum amount of mana that can be spent to win on {0} difficulty is {1:N0}.",
+                    difficulty,
+                    MinimumCostToWin);
+            }
 
             return 0;
         }
@@ -151,11 +154,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
 
                 if (other.Armor == 0)
                 {
-                    output("{0} attacks for {1} damage!", new object[] { Name, damage });
+                    output?.Invoke("{0} attacks for {1} damage!", new object[] { Name, damage });
                 }
                 else
                 {
-                    output("{0} attacks for {1} - {2} = {3} damage!", new object[] { Name, Damage, other.Armor, damage });
+                    output?.Invoke("{0} attacks for {1} - {2} = {3} damage!", new object[] { Name, Damage, other.Armor, damage });
                 }
             }
         }
@@ -529,7 +532,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
             protected override void Cast(Wizard wizard, Action<string, object[]> output)
             {
                 wizard.HitPoints += Delta;
-                output("{0} casts Drain, dealing {1} damage, and healing {1} hit points.", new object[] { wizard.Name, Delta });
+                output?.Invoke("{0} casts Drain, dealing {1} damage, and healing {1} hit points.", new object[] { wizard.Name, Delta });
             }
         }
 
@@ -554,7 +557,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
             /// <inheritdoc />
             protected override void Cast(Wizard wizard, Action<string, object[]> output)
             {
-                output("{0} casts {1}, dealing {2} damage.", new object[] { wizard.Name, Name, Damage });
+                output?.Invoke("{0} casts {1}, dealing {2} damage.", new object[] { wizard.Name, Name, Damage });
             }
 
             /// <inheritdoc />
@@ -585,7 +588,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
             /// <inheritdoc />
             protected override void Cast(Wizard wizard, Action<string, object[]> output)
             {
-                output("{0} casts {1}.", new object[] { wizard.Name, Name });
+                output?.Invoke("{0} casts {1}.", new object[] { wizard.Name, Name });
             }
 
             /// <inheritdoc />
@@ -599,11 +602,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
 
                 if (other.HitPoints < 1)
                 {
-                    output("{0} deals {1} damage. This kills the {2}, and the player wins.", new object[] { Name, Damage, other.Name.ToLowerInvariant() });
+                    output?.Invoke("{0} deals {1} damage. This kills the {2}, and the player wins.", new object[] { Name, Damage, other.Name.ToLowerInvariant() });
                 }
                 else
                 {
-                    output("{0} deals {1} damage; its timer is now {2}.", new object[] { Name, Damage, TurnsLeft - 1 });
+                    output?.Invoke("{0} deals {1} damage; its timer is now {2}.", new object[] { Name, Damage, TurnsLeft - 1 });
                 }
             }
         }
@@ -624,18 +627,18 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
             /// <inheritdoc />
             protected override void Cast(Wizard wizard, Action<string, object[]> output)
             {
-                output("{0} casts {1}.", new object[] { wizard.Name, Name });
+                output?.Invoke("{0} casts {1}.", new object[] { wizard.Name, Name });
             }
 
             /// <inheritdoc />
             protected override void Affect(Wizard wizard, Action<string, object[]> output)
             {
                 wizard.Mana += 101;
-                output("{0} provides 101 mana; its timer is now {1}.", new object[] { Name, TurnsLeft - 1 });
+                output?.Invoke("{0} provides 101 mana; its timer is now {1}.", new object[] { Name, TurnsLeft - 1 });
 
                 if (TurnsLeft - 1 == 0)
                 {
-                    output("{0} wears off.", new object[] { Name });
+                    output?.Invoke("{0} wears off.", new object[] { Name });
                 }
             }
         }
@@ -662,13 +665,13 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
             protected override void Cast(Wizard wizard, Action<string, object[]> output)
             {
                 wizard.Armor += ArmorIncrease;
-                output("{0} casts {1}, increasing armor by {2}.", new object[] { wizard.Name, Name, ArmorIncrease });
+                output?.Invoke("{0} casts {1}, increasing armor by {2}.", new object[] { wizard.Name, Name, ArmorIncrease });
             }
 
             /// <inheritdoc />
             protected override void Affect(Wizard wizard, Action<string, object[]> output)
             {
-                output("{0}'s timer is now {1}.", new object[] { Name, TurnsLeft - 1 });
+                output?.Invoke("{0}'s timer is now {1}.", new object[] { Name, TurnsLeft - 1 });
             }
 
             /// <inheritdoc />
@@ -681,7 +684,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                     wizard.Armor = 0;
                 }
 
-                output("{0} wears off, decreasing armor by {1}.", new object[] { Name, ArmorIncrease });
+                output?.Invoke("{0} wears off, decreasing armor by {1}.", new object[] { Name, ArmorIncrease });
             }
         }
     }

--- a/src/AdventOfCode/Puzzles/Y2015/Day23.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day23.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2015
@@ -32,12 +32,12 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
         /// </returns>
         internal static Tuple<uint, uint> ProcessInstructions(IList<string> instructions, uint initialValue)
         {
-            Register a = new Register()
+            var a = new Register()
             {
                 Value = initialValue,
             };
 
-            Register b = new Register();
+            var b = new Register();
 
             for (int i = 0; i >= 0 && i < instructions.Count;)
             {
@@ -85,13 +85,13 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                         break;
 
                     default:
-                        Console.WriteLine("Instruction '{0}' is not defined.", operation);
+                        Console.Error.WriteLine("Instruction '{0}' is not defined.", operation);
                         return Tuple.Create(uint.MaxValue, uint.MaxValue);
                 }
 
                 if (next == i)
                 {
-                    Console.WriteLine("Instruction at line {0:N0} creates an infinite loop.", i + 1);
+                    Console.Error.WriteLine("Instruction at line {0:N0} creates an infinite loop.", i + 1);
                     break;
                 }
 
@@ -112,11 +112,14 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
             A = result.Item1;
             B = result.Item2;
 
-            Console.WriteLine(
-                "After processing {0:N0} instructions, the value of a is {1:N0} and the value of b is {2:N0}.",
-                instructions.Count,
-                A,
-                B);
+            if (Verbose)
+            {
+                Console.WriteLine(
+                    "After processing {0:N0} instructions, the value of a is {1:N0} and the value of b is {2:N0}.",
+                    instructions.Count,
+                    A,
+                    B);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2015/Day24.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day24.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2015
@@ -38,7 +38,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
             int total = weights.Sum() / compartments;
 
             var optimumConfiguration = Maths.GetCombinations(total, weights)
-                .Select((p) => new { Count = p.Count, QuantumEntanglement = p.Aggregate((x, y) => x * y) })
+                .Select((p) => new { p.Count, QuantumEntanglement = p.Aggregate((x, y) => x * y) })
                 .OrderBy((p) => p.Count)
                 .ThenBy((p) => p.QuantumEntanglement)
                 .First();
@@ -57,10 +57,13 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
 
             QuantumEntanglementOfFirstGroup = GetQuantumEntanglementOfIdealConfiguration(compartments, weights);
 
-            Console.WriteLine(
-                "The quantum entanglement of the ideal configuration of {0:N0} packages is {1:N0}.",
-                weights.Count,
-                QuantumEntanglementOfFirstGroup);
+            if (Verbose)
+            {
+                Console.WriteLine(
+                    "The quantum entanglement of the ideal configuration of {0:N0} packages is {1:N0}.",
+                    weights.Count,
+                    QuantumEntanglementOfFirstGroup);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2015/Day25.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day25.cs
@@ -75,11 +75,14 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
 
             Code = GetCodeForWeatherMachine(row, column);
 
-            Console.WriteLine(
-                "The code for row {0:N0} and column {1:N0} is {2:N0}.",
-                row,
-                column,
-                Code);
+            if (Verbose)
+            {
+                Console.WriteLine(
+                    "The code for row {0:N0} and column {1:N0} is {2:N0}.",
+                    row,
+                    column,
+                    Code);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2016/Day01.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day01.cs
@@ -102,13 +102,16 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
             BlocksToEasterBunnyHQIgnoringDuplicates = CalculateDistance(instructions, ignoreDuplicates: true);
             BlocksToEasterBunnyHQ = CalculateDistance(instructions, ignoreDuplicates: false);
 
-            Console.WriteLine(
-                "The Easter Bunny's headquarters are {0:N0} blocks away.",
-                BlocksToEasterBunnyHQIgnoringDuplicates);
+            if (Verbose)
+            {
+                Console.WriteLine(
+                    "The Easter Bunny's headquarters are {0:N0} blocks away.",
+                    BlocksToEasterBunnyHQIgnoringDuplicates);
 
-            Console.WriteLine(
-                "The Easter Bunny's headquarters are {0:N0} blocks away if it is the first location visited twice.",
-                BlocksToEasterBunnyHQ);
+                Console.WriteLine(
+                    "The Easter Bunny's headquarters are {0:N0} blocks away if it is the first location visited twice.",
+                    BlocksToEasterBunnyHQ);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2016/Day02.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day02.cs
@@ -126,13 +126,16 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
             BathroomCodeDigitKeypad = GetBathroomCode(instructions, DigitGrid);
             BathroomCodeAlphanumericKeypad = GetBathroomCode(instructions, AlphanumericGrid);
 
-            Console.WriteLine(
-                "The code for the bathroom with a digit keypad is {0}.",
-                BathroomCodeDigitKeypad);
+            if (Verbose)
+            {
+                Console.WriteLine(
+                    "The code for the bathroom with a digit keypad is {0}.",
+                    BathroomCodeDigitKeypad);
 
-            Console.WriteLine(
-                "The code for the bathroom with an alphanumeric keypad is {0}.",
-                BathroomCodeAlphanumericKeypad);
+                Console.WriteLine(
+                    "The code for the bathroom with an alphanumeric keypad is {0}.",
+                    BathroomCodeAlphanumericKeypad);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2016/Day03.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day03.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2016
@@ -61,8 +61,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
             PossibleTrianglesByRows = GetPossibleTriangleCount(dimensions, readAsColumns: false);
             PossibleTrianglesByColumns = GetPossibleTriangleCount(dimensions, readAsColumns: true);
 
-            Console.WriteLine("The number of possible triangles using rows is {0:N0}.", PossibleTrianglesByRows);
-            Console.WriteLine("The number of possible triangles using columns is {0:N0}.", PossibleTrianglesByColumns);
+            if (Verbose)
+            {
+                Console.WriteLine("The number of possible triangles using rows is {0:N0}.", PossibleTrianglesByRows);
+                Console.WriteLine("The number of possible triangles using columns is {0:N0}.", PossibleTrianglesByColumns);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2016/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day04.cs
@@ -101,8 +101,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
             SumOfSectorIdsOfRealRooms = SumOfRealRoomSectorIds(names);
             SectorIdOfNorthPoleObjectsRoom = GetSectorIdOfNorthPoleObjectsRoom(names);
 
-            Console.WriteLine("The sum of the sector Ids of the real rooms is {0:N0}.", SumOfSectorIdsOfRealRooms);
-            Console.WriteLine("The sector ID of the room where North Pole objects are stored is {0:N0}.", SumOfSectorIdsOfRealRooms);
+            if (Verbose)
+            {
+                Console.WriteLine("The sum of the sector Ids of the real rooms is {0:N0}.", SumOfSectorIdsOfRealRooms);
+                Console.WriteLine("The sector ID of the room where North Pole objects are stored is {0:N0}.", SumOfSectorIdsOfRealRooms);
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2016/Day05.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day05.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2016
@@ -90,8 +90,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
             Password = GeneratePassword(doorId, isPositionSpecifiedByHash: false);
             PasswordWhenPositionIsIndicated = GeneratePassword(doorId, isPositionSpecifiedByHash: true);
 
-            Console.WriteLine($"The password for door '{doorId}' is '{Password}'.");
-            Console.WriteLine($"The password for door '{doorId}' is '{PasswordWhenPositionIsIndicated}' when the position is specified in the hash.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The password for door '{doorId}' is '{Password}'.");
+                Console.WriteLine($"The password for door '{doorId}' is '{PasswordWhenPositionIsIndicated}' when the position is specified in the hash.");
+            }
 
             return 0;
         }
@@ -124,14 +127,14 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
         /// <returns>
         /// A <see cref="string"/> containing the hexadecimal representation of <paramref name="hashBytes"/>.
         /// </returns>
-        private static string GetStringForHash(byte[] hashBytes)
+        private static string GetStringForHash(ReadOnlySpan<byte> hashBytes)
         {
             var hash = new StringBuilder("0000");
 
             // Skip the first 2 bytes as they should already have been checked to be zero
             for (int i = 2; i < hashBytes.Length; i++)
             {
-                hash.AppendFormat(CultureInfo.InvariantCulture, "{0:x2}", hashBytes[i]);
+                hash.Append(hashBytes[i].ToString("x2", CultureInfo.InvariantCulture));
             }
 
             return hash.ToString();

--- a/src/AdventOfCode/Puzzles/Y2016/Day06.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day06.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2016
@@ -64,8 +64,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
             ErrorCorrectedMessage = DecryptMessage(messages, leastLikely: false);
             ModifiedErrorCorrectedMessage = DecryptMessage(messages, leastLikely: true);
 
-            Console.WriteLine($"The error-corrected message using the most likley letters is: {ErrorCorrectedMessage}.");
-            Console.WriteLine($"The error-corrected message using the least likely letters is: {ModifiedErrorCorrectedMessage}.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The error-corrected message using the most likley letters is: {ErrorCorrectedMessage}.");
+                Console.WriteLine($"The error-corrected message using the least likely letters is: {ModifiedErrorCorrectedMessage}.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2016/Day07.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day07.cs
@@ -4,6 +4,7 @@
 namespace MartinCostello.AdventOfCode.Puzzles.Y2016
 {
     using System;
+    using System.Buffers;
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
@@ -87,8 +88,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
             IPAddressesSupportingTls = addresses.Count(DoesIPAddressSupportTls);
             IPAddressesSupportingSsl = addresses.Count(DoesIPAddressSupportSsl);
 
-            Console.WriteLine("{0:N0} IPv7 addresses support TLS.", IPAddressesSupportingTls);
-            Console.WriteLine("{0:N0} IPv7 addresses support SSL.", IPAddressesSupportingSsl);
+            if (Verbose)
+            {
+                Console.WriteLine("{0:N0} IPv7 addresses support TLS.", IPAddressesSupportingTls);
+                Console.WriteLine("{0:N0} IPv7 addresses support SSL.", IPAddressesSupportingSsl);
+            }
 
             return 0;
         }
@@ -125,9 +129,9 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
         /// <returns>
         /// An <see cref="IList{T}"/> containing the extracted ABA values.
         /// </returns>
-        private static IList<string> ExtractAbas(string value)
+        private static IList<string> ExtractAbas(ReadOnlySpan<char> value)
         {
-            IList<string> result = new List<string>();
+            var result = new List<string>();
 
             for (int i = 0; i < value.Length - 2; i++)
             {
@@ -135,9 +139,22 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
                 char ch2 = value[i + 1];
                 char ch3 = value[i + 2];
 
-                if (ch1 != ch2 && ch1 == ch3)
+                char[] shared = ArrayPool<char>.Shared.Rent(3);
+
+                try
                 {
-                    result.Add(new string(new[] { ch1, ch2, ch3 }));
+                    shared[0] = ch1;
+                    shared[1] = ch2;
+                    shared[2] = ch3;
+
+                    if (ch1 != ch2 && ch1 == ch3)
+                    {
+                        result.Add(new string(shared.AsSpan(0, 3)));
+                    }
+                }
+                finally
+                {
+                    ArrayPool<char>.Shared.Return(shared);
                 }
             }
 
@@ -155,7 +172,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
             supernets = new List<string>();
             hypernets = new List<string>();
 
-            StringBuilder builder = new StringBuilder();
+            var builder = new StringBuilder();
 
             bool isInHypernet = false;
 

--- a/src/AdventOfCode/Puzzles/Y2016/Day08.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day08.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2016
@@ -63,7 +63,10 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
 
             PixelsLit = GetPixelsLit(instructions, width: 50, height: 6);
 
-            Console.WriteLine($"There are {PixelsLit:N0} pixels lit.");
+            if (Verbose)
+            {
+                Console.WriteLine($"There are {PixelsLit:N0} pixels lit.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2016/Day09.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day09.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2016
@@ -42,8 +42,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
             DecompressedLengthVersion1 = GetDecompressedLength(data, version: 1);
             DecompressedLengthVersion2 = GetDecompressedLength(data, version: 2);
 
-            Console.WriteLine($"The decompressed length of the data using version 1 of the algorithm is {DecompressedLengthVersion1:N0}.");
-            Console.WriteLine($"The decompressed length of the data using version 2 of the algorithm is {DecompressedLengthVersion2:N0}.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The decompressed length of the data using version 1 of the algorithm is {DecompressedLengthVersion1:N0}.");
+                Console.WriteLine($"The decompressed length of the data using version 2 of the algorithm is {DecompressedLengthVersion2:N0}.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2016/Day10.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day10.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2016
@@ -76,8 +76,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
             BotThatCompares61And17Microchips = result.Item1;
             ProductOfMicrochipsInBins012 = result.Item2;
 
-            Console.WriteLine($"The number of the bot that compares value-61 and value-17 microchips is {BotThatCompares61And17Microchips:N0}.");
-            Console.WriteLine($"The product of the microchips in output bins 0, 1 and 2 is {ProductOfMicrochipsInBins012:N0}.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The number of the bot that compares value-61 and value-17 microchips is {BotThatCompares61And17Microchips:N0}.");
+                Console.WriteLine($"The product of the microchips in output bins 0, 1 and 2 is {ProductOfMicrochipsInBins012:N0}.");
+            }
 
             return 0;
         }
@@ -322,9 +325,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
             /// </returns>
             private Bin GetBin(int number)
             {
-                Bin bin;
-
-                if (!Bins.TryGetValue(number, out bin))
+                if (!Bins.TryGetValue(number, out Bin bin))
                 {
                     Bins[number] = bin = new Bin(number);
                 }

--- a/src/AdventOfCode/Puzzles/Y2016/Day12.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day12.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2016
@@ -183,8 +183,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
             registers = Process(instructions, initialValueOfC: 1);
             ValueInRegisterAWhenInitializedWithIgnitionKey = registers['a'];
 
-            Console.WriteLine($"The value left in register a is {ValueInRegisterA:N0}.");
-            Console.WriteLine($"The value left in register a if c is initialized to 1 is {ValueInRegisterAWhenInitializedWithIgnitionKey:N0}.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The value left in register a is {ValueInRegisterA:N0}.");
+                Console.WriteLine($"The value left in register a if c is initialized to 1 is {ValueInRegisterAWhenInitializedWithIgnitionKey:N0}.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2016/Day14.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day14.cs
@@ -97,8 +97,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
             IndexOfKey64 = GetOneTimePadKeyIndex(salt, 64, useKeyStretching: false);
             IndexOfKey64WithStretching = GetOneTimePadKeyIndex(salt, 64, useKeyStretching: true);
 
-            Console.WriteLine($"The index that produces the 64th one-time pad key is {IndexOfKey64:N0}.");
-            Console.WriteLine($"The index that produces the 64th one-time pad key when using key stretching is {IndexOfKey64WithStretching:N0}.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The index that produces the 64th one-time pad key is {IndexOfKey64:N0}.");
+                Console.WriteLine($"The index that produces the 64th one-time pad key when using key stretching is {IndexOfKey64WithStretching:N0}.");
+            }
 
             return 0;
         }
@@ -214,7 +217,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
 
             foreach (byte b in collection)
             {
-                hash.AppendFormat(CultureInfo.InvariantCulture, "{0:x2}", b);
+                hash.Append(b.ToString("x2", CultureInfo.InvariantCulture));
             }
 
             return hash.ToString();

--- a/src/AdventOfCode/Puzzles/Y2016/Day15.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day15.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2016
@@ -59,8 +59,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
             TimeOfFirstButtonPress = FindTimeForCapsuleRelease(input);
             TimeOfFirstButtonPressWithExtraDisc = FindTimeForCapsuleRelease(input.Concat(extraDisc));
 
-            Console.WriteLine($"The first time the button can be pressed to get a capsule is {TimeOfFirstButtonPress:N0}.");
-            Console.WriteLine($"The first time the button can be pressed to get a capsule with the extra disc present is {TimeOfFirstButtonPressWithExtraDisc:N0}.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The first time the button can be pressed to get a capsule is {TimeOfFirstButtonPress:N0}.");
+                Console.WriteLine($"The first time the button can be pressed to get a capsule with the extra disc present is {TimeOfFirstButtonPressWithExtraDisc:N0}.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2016/Day16.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day16.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2016
@@ -45,7 +45,10 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
 
             Checksum = GetDiskChecksum(initial, size);
 
-            Console.WriteLine($"The checksum for the generated disk data is '{Checksum}'.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The checksum for the generated disk data is '{Checksum}'.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2016/Day18.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day18.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2016
@@ -23,10 +23,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
         /// </summary>
         /// <param name="firstRowTiles">The map of tiles in the first row.</param>
         /// <param name="rows">The number of rows.</param>
+        /// <param name="printGrid">Whether to output the grid to the console.</param>
         /// <returns>
         /// The number of safe tiles in the map described by <paramref name="firstRowTiles"/>.
         /// </returns>
-        internal static int FindSafeTileCount(string firstRowTiles, int rows)
+        internal static int FindSafeTileCount(string firstRowTiles, int rows, bool printGrid = false)
         {
             int width = firstRowTiles.Length;
 
@@ -50,9 +51,12 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
                 }
             }
 
-            if (!Console.IsOutputRedirected && rows <= Console.WindowHeight)
+            if (printGrid)
             {
-                PrintGrid(tiles);
+                if (!Console.IsOutputRedirected && rows <= Console.WindowHeight)
+                {
+                    PrintGrid(tiles);
+                }
             }
 
             return (width * rows) - CountTrapTiles(tiles);
@@ -64,9 +68,12 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
             int rows = ParseInt32(args[0]);
             string firstRowTiles = args.Length > 1 ? args[1] : ReadResourceAsString().TrimEnd();
 
-            SafeTileCount = FindSafeTileCount(firstRowTiles, rows);
+            SafeTileCount = FindSafeTileCount(firstRowTiles, rows, Verbose);
 
-            Console.WriteLine($"The number of safe tiles is {SafeTileCount:N0}.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The number of safe tiles is {SafeTileCount:N0}.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2016/Day19.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day19.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2016
@@ -43,7 +43,10 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
 
             ElfWithAllPresents = FindElfThatGetsAllPresents(count, version);
 
-            Console.WriteLine($"The elf that gets all the presents using version {version} of the rules is {ElfWithAllPresents:N0}.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The elf that gets all the presents using version {version} of the rules is {ElfWithAllPresents:N0}.");
+            }
 
             return 0;
         }
@@ -117,7 +120,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
         /// </returns>
         private static LinkedList<int> CreateCircle(int count)
         {
-            LinkedList<int> circle = new LinkedList<int>();
+            var circle = new LinkedList<int>();
             var current = circle.AddFirst(1);
 
             while (circle.Count < count)

--- a/src/AdventOfCode/Puzzles/Y2016/Day20.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day20.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2016
@@ -125,13 +125,14 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
         {
             IList<string> ranges = ReadResourceAsLines();
 
-            uint count;
-
-            LowestNonblockedIP = GetLowestNonblockedIP(uint.MaxValue, ranges, out count);
+            LowestNonblockedIP = GetLowestNonblockedIP(uint.MaxValue, ranges, out uint count);
             AllowedIPCount = count;
 
-            Console.WriteLine($"The lowest-valued IP that is not blocked is {LowestNonblockedIP}.");
-            Console.WriteLine($"The number of IP addresses allowed is {AllowedIPCount:N0}.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The lowest-valued IP that is not blocked is {LowestNonblockedIP}.");
+                Console.WriteLine($"The number of IP addresses allowed is {AllowedIPCount:N0}.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2016/Day21.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day21.cs
@@ -122,7 +122,10 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
 
             ScrambledResult = Scramble(text, instructions, reverse);
 
-            Console.WriteLine($"The result of {(reverse ? "un" : string.Empty)}scrambling '{text}' is '{ScrambledResult}'.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The result of {(reverse ? "un" : string.Empty)}scrambling '{text}' is '{ScrambledResult}'.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2016/Day23.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day23.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2016
@@ -29,7 +29,10 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
             IDictionary<char, int> registers = Day12.Process(instructions, initialValueOfA: input);
             SafeValue = registers['a'];
 
-            Console.WriteLine($"The value to send to the safe for an input of {input:N0} is '{SafeValue}'.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The value to send to the safe for an input of {input:N0} is '{SafeValue}'.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2016/Day25.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day25.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2016
@@ -28,7 +28,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
                 int lastSignal = 1;
                 int iterations = 0;
 
-                Func<int, bool> signal = (p) =>
+                bool Signal(int p)
                 {
                     // If the signal is not 0 or 1, then not of interest
                     bool stop = true;
@@ -60,12 +60,12 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
                     }
 
                     return stop;
-                };
+                }
 
                 Day12.Process(
                     instructions,
                     initialValueOfA: i,
-                    signal: signal);
+                    signal: Signal);
 
                 if (isRepeating)
                 {
@@ -74,7 +74,10 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2016
                 }
             }
 
-            Console.WriteLine($"The lowest positive integer that produces a clock signal is '{ClockSignalValue:N0}'.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The lowest positive integer that produces a clock signal is '{ClockSignalValue:N0}'.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2017/Day01.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day01.cs
@@ -62,8 +62,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2017
             CaptchaSolutionNext = CalculateSum(digits, useOppositeDigit: false);
             CaptchaSolutionOpposite = CalculateSum(digits, useOppositeDigit: true);
 
-            Console.WriteLine($"The solution to the first captcha is {CaptchaSolutionNext:N0}.");
-            Console.WriteLine($"The solution to the second captcha is {CaptchaSolutionOpposite:N0}.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The solution to the first captcha is {CaptchaSolutionNext:N0}.");
+                Console.WriteLine($"The solution to the second captcha is {CaptchaSolutionOpposite:N0}.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2017/Day02.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day02.cs
@@ -98,8 +98,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2017
             ChecksumForDifference = CalculateChecksum(spreadsheet, forEvenlyDivisible: false);
             ChecksumForEvenlyDivisible = CalculateChecksum(spreadsheet, forEvenlyDivisible: true);
 
-            Console.WriteLine($"The checksum for the spreadsheet using differences is {ChecksumForDifference:N0}.");
-            Console.WriteLine($"The checksum for the spreadsheet using even division is {ChecksumForEvenlyDivisible:N0}.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The checksum for the spreadsheet using differences is {ChecksumForDifference:N0}.");
+                Console.WriteLine($"The checksum for the spreadsheet using even division is {ChecksumForEvenlyDivisible:N0}.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2017/Day03.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day03.cs
@@ -180,8 +180,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2017
             Steps = ComputeSteps(square);
             FirstStorageLargerThanInput = ComputeFirstLargestWrittenValue(square);
 
-            Console.WriteLine($"The number of steps required to carry the data from square {square:N0} all the way to the access port is {Steps:N0}.");
-            Console.WriteLine($"The first value written that is larger than square {square:N0} is {FirstStorageLargerThanInput:N0}.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The number of steps required to carry the data from square {square:N0} all the way to the access port is {Steps:N0}.");
+                Console.WriteLine($"The first value written that is larger than square {square:N0} is {FirstStorageLargerThanInput:N0}.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2017/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day04.cs
@@ -57,8 +57,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2017
             ValidPassphraseCountV1 = passphrases.Where((p) => IsPassphraseValid(p, 1)).Count();
             ValidPassphraseCountV2 = passphrases.Where((p) => IsPassphraseValid(p, 2)).Count();
 
-            Console.WriteLine($"There are {ValidPassphraseCountV1:N0} valid passphrases using version 1 of the policy.");
-            Console.WriteLine($"There are {ValidPassphraseCountV2:N0} valid passphrases using version 2 of the policy.");
+            if (Verbose)
+            {
+                Console.WriteLine($"There are {ValidPassphraseCountV1:N0} valid passphrases using version 1 of the policy.");
+                Console.WriteLine($"There are {ValidPassphraseCountV2:N0} valid passphrases using version 2 of the policy.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2017/Day05.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day05.cs
@@ -67,8 +67,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2017
             StepsToExitV1 = Execute(program, 1);
             StepsToExitV2 = Execute(program, 2);
 
-            Console.WriteLine($"It takes {StepsToExitV1:N0} to reach the exit using version 1.");
-            Console.WriteLine($"It takes {StepsToExitV2:N0} to reach the exit using version 2.");
+            if (Verbose)
+            {
+                Console.WriteLine($"It takes {StepsToExitV1:N0} to reach the exit using version 1.");
+                Console.WriteLine($"It takes {StepsToExitV2:N0} to reach the exit using version 2.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2017/Day06.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day06.cs
@@ -53,8 +53,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2017
             CycleCount = cycleCount;
             LoopSize = loopSize;
 
-            Console.WriteLine($"{CycleCount:N0} redistribution cycles must be completed before a configuration is produced that has been seen before.");
-            Console.WriteLine($"{LoopSize:N0} cycles are in the infinite loop that arises from the configuration in the input.");
+            if (Verbose)
+            {
+                Console.WriteLine($"{CycleCount:N0} redistribution cycles must be completed before a configuration is produced that has been seen before.");
+                Console.WriteLine($"{LoopSize:N0} cycles are in the infinite loop that arises from the configuration in the input.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2017/Day07.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day07.cs
@@ -60,8 +60,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2017
             BottomProgramName = FindBottomProgramName(structure);
             DesiredWeightOfUnbalancedDisc = FindDesiredWeightOfUnbalancedDisc(structure);
 
-            Console.WriteLine($"The name of the bottom program is '{BottomProgramName}'.");
-            Console.WriteLine($"The desired weight of the program to balance the structure is {DesiredWeightOfUnbalancedDisc:N0}.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The name of the bottom program is '{BottomProgramName}'.");
+                Console.WriteLine($"The desired weight of the program to balance the structure is {DesiredWeightOfUnbalancedDisc:N0}.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2017/Day08.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day08.cs
@@ -56,8 +56,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2017
             HighestRegisterValueAtEnd = FindHighestRegisterValueAtEnd(instructions);
             HighestRegisterValueDuring = FindHighestRegisterValueDuring(instructions);
 
-            Console.WriteLine($"The largest value in any register after executing the input is {HighestRegisterValueAtEnd:N0}.");
-            Console.WriteLine($"The largest value in any register at any point while executing the input was {HighestRegisterValueDuring:N0}.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The largest value in any register after executing the input is {HighestRegisterValueAtEnd:N0}.");
+                Console.WriteLine($"The largest value in any register at any point while executing the input was {HighestRegisterValueDuring:N0}.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2017/Day09.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day09.cs
@@ -109,8 +109,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2017
             TotalScore = score;
             GarbageCount = garbageCount;
 
-            Console.WriteLine($"The total score for all the groups is {TotalScore:N0}.");
-            Console.WriteLine($"There are {GarbageCount:N0} non-canceled characters within the garbage.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The total score for all the groups is {TotalScore:N0}.");
+                Console.WriteLine($"There are {GarbageCount:N0} non-canceled characters within the garbage.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2017/Day10.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day10.cs
@@ -92,8 +92,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2017
             ProductOfFirstTwoElements = FindProductOfFirstTwoHashElements(SequenceLength, lengths);
             DenseHash = ComputeHash(rawLengths);
 
-            Console.WriteLine($"The product of the first two elements of the hash is {ProductOfFirstTwoElements:N0}.");
-            Console.WriteLine($"The hexadecimal dense hash of the input is {DenseHash}.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The product of the first two elements of the hash is {ProductOfFirstTwoElements:N0}.");
+                Console.WriteLine($"The hexadecimal dense hash of the input is {DenseHash}.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2017/Day11.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day11.cs
@@ -90,8 +90,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2017
 
             (MinimumSteps, MaximumDistance) = FindStepRange(path);
 
-            Console.WriteLine($"The minimum number of steps required to reach the child process is {MinimumSteps:N0}.");
-            Console.WriteLine($"The maximum distance reached by the child process was {MaximumDistance:N0}.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The minimum number of steps required to reach the child process is {MinimumSteps:N0}.");
+                Console.WriteLine($"The maximum distance reached by the child process was {MaximumDistance:N0}.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2017/Day12.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day12.cs
@@ -76,8 +76,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2017
             ProgramsInGroupOfProgram0 = GetProgramsInGroup(0, pipes);
             NumberOfGroups = GetGroupsInNetwork(pipes);
 
-            Console.WriteLine($"There are {ProgramsInGroupOfProgram0:N0} programs in the group that contains program ID 0.");
-            Console.WriteLine($"There are {NumberOfGroups:N0} groups in the network of pipes.");
+            if (Verbose)
+            {
+                Console.WriteLine($"There are {ProgramsInGroupOfProgram0:N0} programs in the group that contains program ID 0.");
+                Console.WriteLine($"There are {NumberOfGroups:N0} groups in the network of pipes.");
+            }
 
             return 0;
         }

--- a/src/AdventOfCode/Puzzles/Y2017/Day13.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day13.cs
@@ -110,8 +110,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2017
             Severity = GetSeverityOfTrip(depthRanges);
             ShortestDelay = GetShortestDelayForNeverCaught(depthRanges);
 
-            Console.WriteLine($"The severity of the trip through the firewall is {Severity:N0}.");
-            Console.WriteLine($"The fewest number of picoseconds that the packet needs to be delayed by to pass through the firewall without being caught is {ShortestDelay:N0}.");
+            if (Verbose)
+            {
+                Console.WriteLine($"The severity of the trip through the firewall is {Severity:N0}.");
+                Console.WriteLine($"The fewest number of picoseconds that the packet needs to be delayed by to pass through the firewall without being caught is {ShortestDelay:N0}.");
+            }
 
             return 0;
         }


### PR DESCRIPTION
  * Add a verbose mode so that `Console.WriteLine()` is only called when generating the answers when run from the console. This should make CI and benchmarks a lot faster.
  * Some minor refactoring to use `ReadOnlySpan<char>` instead of string and other minor style changes, like using `var`.
