### PR TITLE
Add CPU Profiling

### DIFF
--- a/tests/AdventOfCode.Benchmarks/AdventOfCode.Benchmarks.csproj
+++ b/tests/AdventOfCode.Benchmarks/AdventOfCode.Benchmarks.csproj
@@ -7,6 +7,8 @@
     <RootNamespace>MartinCostello.AdventOfCode.Benchmarks</RootNamespace>
     <Summary>$(Description)</Summary>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <!-- Workaround for https://github.com/dotnet/BenchmarkDotNet/pull/1420 -->
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\AdventOfCode\AdventOfCode.csproj" />

--- a/tests/AdventOfCode.Benchmarks/PuzzleBenchmarks.cs
+++ b/tests/AdventOfCode.Benchmarks/PuzzleBenchmarks.cs
@@ -6,7 +6,9 @@ namespace MartinCostello.AdventOfCode.Benchmarks
     using System;
     using System.Collections.Generic;
     using BenchmarkDotNet.Attributes;
+    using BenchmarkDotNet.Diagnosers;
 
+    [EventPipeProfiler(EventPipeProfile.CpuSampling)]
     [MemoryDiagnoser]
     public class PuzzleBenchmarks
     {


### PR DESCRIPTION
  * Add a CPU profiler to the benchmarks.
  * Workaround bug in BenchmarkDotNet 0.12.1.
