### PR TITLE
.NET 5 preparation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{config,csproj,json,props,ruleset,targets,yml}]
+[*.{config,csproj,json,props,ruleset,targets,vsconfig,yml}]
 indent_size = 2
 
 # Code files

--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,11 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Component.CoreEditor",
+    "Microsoft.VisualStudio.Workload.CoreEditor",
+    "Microsoft.NetCore.Component.Runtime.3.1",
+    "Microsoft.NetCore.Component.SDK",
+    "Microsoft.VisualStudio.Component.Roslyn.Compiler",
+    "Microsoft.VisualStudio.Component.Roslyn.LanguageServices"
+  ]
+}

--- a/AdventOfCode.sln
+++ b/AdventOfCode.sln
@@ -7,6 +7,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		.vsconfig = .vsconfig
 		AdventOfCode.ruleset = AdventOfCode.ruleset
 		AdventOfCode.snk = AdventOfCode.snk
 		benchmark.ps1 = benchmark.ps1

--- a/global.json
+++ b/global.json
@@ -1,5 +1,7 @@
 {
   "sdk": {
-    "version": "3.1.201"
+    "version": "3.1.201",
+    "allowPrerelease": false,
+    "rollForward": "latestMajor"
   }
 }

--- a/src/AdventOfCode/Puzzles/Y2015/Day06.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day06.cs
@@ -196,7 +196,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                 // Split the instructions into 'words'
                 string[] words = value.Split(' ');
 
-                string firstWord = words.ElementAtOrDefault(0);
+                string? firstWord = words.ElementAtOrDefault(0);
 
                 string? action = null;
                 string? origin = null;
@@ -205,7 +205,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                 // Determine the action to perform for this instruction (OFF, ON or TOGGLE)
                 if (string.Equals(firstWord, "turn", StringComparison.OrdinalIgnoreCase))
                 {
-                    string secondWord = words.ElementAtOrDefault(1);
+                    string? secondWord = words.ElementAtOrDefault(1);
 
                     if (string.Equals(secondWord, "off", StringComparison.OrdinalIgnoreCase))
                     {
@@ -277,7 +277,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                 // Split the instructions into 'words'
                 string[] words = value.Split(' ');
 
-                string firstWord = words.ElementAtOrDefault(0);
+                string? firstWord = words.ElementAtOrDefault(0);
 
                 int? delta = null;
                 string? origin = null;
@@ -286,7 +286,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                 // Determine the action to perform for this instruction (OFF, ON or TOGGLE)
                 if (string.Equals(firstWord, "turn", StringComparison.OrdinalIgnoreCase))
                 {
-                    string secondWord = words.ElementAtOrDefault(1);
+                    string? secondWord = words.ElementAtOrDefault(1);
 
                     if (string.Equals(secondWord, "off", StringComparison.OrdinalIgnoreCase))
                     {

--- a/src/AdventOfCode/Puzzles/Y2015/Day07.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day07.cs
@@ -54,14 +54,14 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                     string[] words = pair.Value;
                     ushort? solvedValue = null;
 
-                    string firstOperand = words.FirstOrDefault();
-                    string secondOperand;
+                    string? firstOperand = words.FirstOrDefault();
+                    string? secondOperand;
 
                     if (words.Length == 1)
                     {
                         // "123 -> x" or " -> "lx -> a"
                         // Is the instruction a value or a previously solved value?
-                        if (ushort.TryParse(firstOperand, out ushort value) || result.TryGetValue(firstOperand, out value))
+                        if (ushort.TryParse(firstOperand, out ushort value) || result.TryGetValue(firstOperand!, out value))
                         {
                             result[wireId] = value;
                         }
@@ -73,7 +73,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
 
                         // Is the second operand a value or a previously solved value?
                         if (ushort.TryParse(secondOperand, out ushort value) ||
-                            result.TryGetValue(secondOperand, out value))
+                            result.TryGetValue(secondOperand!, out value))
                         {
                             result[wireId] = (ushort)~value;
                         }
@@ -83,11 +83,11 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                         secondOperand = words.ElementAtOrDefault(2);
 
                         // Are both operands a value or a previously solved value?
-                        if ((ushort.TryParse(firstOperand, out ushort firstValue) || result.TryGetValue(firstOperand, out firstValue)) &&
-                            (ushort.TryParse(secondOperand, out ushort secondValue) || result.TryGetValue(secondOperand, out secondValue)))
+                        if ((ushort.TryParse(firstOperand, out ushort firstValue) || result.TryGetValue(firstOperand!, out firstValue)) &&
+                            (ushort.TryParse(secondOperand, out ushort secondValue) || result.TryGetValue(secondOperand!, out secondValue)))
                         {
-                            string operation = words.ElementAtOrDefault(1);
-                            solvedValue = TrySolveValueForOperation(operation, firstValue, secondValue);
+                            string? operation = words.ElementAtOrDefault(1);
+                            solvedValue = TrySolveValueForOperation(operation!, firstValue, secondValue);
                         }
                     }
 

--- a/src/AdventOfCode/Puzzles/Y2015/Day21.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day21.cs
@@ -43,7 +43,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                 goldSpent += human.Upgrade(shop.PurchaseArmor(armor));
             }
 
-            foreach (string ring in rings.Distinct().Take(2))
+            foreach (string ring in rings!.Distinct().Take(2))
             {
                 goldSpent += human.Upgrade(shop.PurchaseRing(ring));
             }

--- a/src/AdventOfCode/Puzzles/Y2015/Day23.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day23.cs
@@ -47,9 +47,9 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                 string instruction = instructions[i];
                 string[] split = instruction.Split(' ');
 
-                string operation = split.ElementAtOrDefault(0);
-                string registerOrOffset = split.ElementAtOrDefault(1);
-                string offset = split.ElementAtOrDefault(2);
+                string? operation = split.ElementAtOrDefault(0);
+                string? registerOrOffset = split.ElementAtOrDefault(1);
+                string? offset = split.ElementAtOrDefault(2);
 
                 int next = i + 1;
 
@@ -72,7 +72,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                         break;
 
                     case "jie":
-                        if ((registerOrOffset.Split(',')[0].Trim() == "a" ? a : b).Value % 2 == 0)
+                        if ((registerOrOffset!.Split(',')[0].Trim() == "a" ? a : b).Value % 2 == 0)
                         {
                             next = i + ParseInt32(offset);
                         }
@@ -80,7 +80,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                         break;
 
                     case "jio":
-                        if ((registerOrOffset.Split(',')[0].Trim() == "a" ? a : b).Value == 1)
+                        if ((registerOrOffset!.Split(',')[0].Trim() == "a" ? a : b).Value == 1)
                         {
                             next = i + ParseInt32(offset);
                         }


### PR DESCRIPTION
  * Port changes from #116.
  * Disable automatic use of prerelease SDKs if installed and allow roll-foward to the latest installed stable SDK.
  * Add a `.vsconfig` file for the solution.