### PR TITLE
Disable logging in benchmarks

### DIFF
--- a/tests/AdventOfCode.Benchmarks/PuzzleBenchmarks.cs
+++ b/tests/AdventOfCode.Benchmarks/PuzzleBenchmarks.cs
@@ -88,9 +88,15 @@ namespace MartinCostello.AdventOfCode.Benchmarks
             public PuzzleInput(params string[] args)
                 : base(args)
             {
+                Puzzle = new T() { Verbose = false };
+
+                if (Puzzle is Puzzle puzzle)
+                {
+                    puzzle.Logger = new NullLogger();
+                }
             }
 
-            public override IPuzzle Puzzle { get; } = new T();
+            public override IPuzzle Puzzle { get; }
         }
 
         public abstract class PuzzleInput
@@ -120,6 +126,19 @@ namespace MartinCostello.AdventOfCode.Benchmarks
                 }
 
                 return name;
+            }
+        }
+
+        private sealed class NullLogger : ILogger
+        {
+            public void WriteGrid(bool[,] array, char falseChar, char trueChar)
+            {
+                // No-op
+            }
+
+            public void WriteLine(string format, params object[] args)
+            {
+                // No-op
             }
         }
     }


### PR DESCRIPTION
Use a no-op logger in the benchmarks so that console writes aren't included.
