### PR TITLE
Fix analyzer warnings

### DIFF
--- a/src/AdventOfCode/Puzzles/Y2015/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day04.cs
@@ -47,7 +47,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                     try
                     {
                         // Does this range start at a value greater than an already found value?
-                        if (solutions.Count > 0)
+                        if (!solutions.IsEmpty)
                         {
                             int bestSolution = solutions.Min();
 
@@ -106,7 +106,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                     }
                 });
 
-            if (solutions.Count < 1)
+            if (solutions.IsEmpty)
             {
                 throw new ArgumentException("No answer was found for the specified secret key.", nameof(secretKey));
             }

--- a/src/AdventOfCode/Puzzles/Y2015/Day08.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day08.cs
@@ -47,7 +47,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                     case '\"':
                     case '\\':
                     case '\'':
-                        builder.Append("\\");
+                        builder.Append('\\');
                         break;
 
                     default:
@@ -57,7 +57,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015
                 builder.Append(current);
             }
 
-            builder.Append("\"");
+            builder.Append('\"');
 
             return builder.Length;
         }

--- a/src/AdventOfCode/Puzzles/Y2019/Day03.cs
+++ b/src/AdventOfCode/Puzzles/Y2019/Day03.cs
@@ -153,7 +153,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2019
         private static (int x, int y) GetDelta(string instruction)
         {
             char direction = instruction[0];
-            int distance = ParseInt32(instruction[1..]);
+            int distance = ParseInt32(instruction.AsSpan(1));
 
             return direction switch
             {


### PR DESCRIPTION
Fix new analyzer warnings discovered by version 3.3.0 of the Roslyn analyzers (see #116).