### PR TITLE
Refactor HttpServerFixture

### DIFF
--- a/tests/AdventOfCode.Tests/Api/HttpServerFixture.cs
+++ b/tests/AdventOfCode.Tests/Api/HttpServerFixture.cs
@@ -4,9 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
-using System.Threading.Tasks;
 using MartinCostello.Logging.XUnit;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
@@ -16,7 +14,6 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace MartinCostello.AdventOfCode.Api


### PR DESCRIPTION
Refactor `HttpServerFixture` to use a similar approach that the refactored `WebApplicationFactory<T>` in the dotnet-minimal-api-integration-testing repo uses.
