### PR TITLE
Render version in page source

### DIFF
--- a/src/AdventOfCode/Pages/Shared/_Layout.cshtml
+++ b/src/AdventOfCode/Pages/Shared/_Layout.cshtml
@@ -87,5 +87,6 @@
     Commit SHA:    @(GitMetadata.Commit)
     Commit branch: @(GitMetadata.Branch)
     Timestamp:     @(GitMetadata.Timestamp)
+    Version:       @(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription)
 -->
 </html>


### PR DESCRIPTION
Render the .NET version in the page's source.
