### PR TITLE
Make SquareGrid generic and add Manhattan Distance extension

### DIFF
--- a/src/AdventOfCode/PointExtensions.cs
+++ b/src/AdventOfCode/PointExtensions.cs
@@ -9,6 +9,15 @@ namespace System.Drawing;
 internal static class PointExtensions
 {
     /// <summary>
+    /// Returns the absolute Manhattan Distance of a point.
+    /// </summary>
+    /// <param name="value">The value.</param>
+    /// <returns>
+    /// The Manhattan Distance of <paramref name="value"/>.
+    /// </returns>
+    public static int ManhattanDistance(this Point value) => value.ManhattanDistance(Point.Empty);
+
+    /// <summary>
     /// Returns the Manhattan Distance between two points.
     /// </summary>
     /// <param name="value">The origin value.</param>

--- a/src/AdventOfCode/PointExtensions.cs
+++ b/src/AdventOfCode/PointExtensions.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace System.Drawing;
+
+/// <summary>
+/// A class containing extension methods for the <see cref="Point"/> structure. This class cannot be inherited.
+/// </summary>
+internal static class PointExtensions
+{
+    /// <summary>
+    /// Returns the Manhattan Distance between two points.
+    /// </summary>
+    /// <param name="value">The origin value.</param>
+    /// <param name="other">The value to calculate the distance to.</param>
+    /// <returns>
+    /// The Manhattan Distance between <paramref name="value"/> and <paramref name="other"/>.
+    /// </returns>
+    public static int ManhattanDistance(this Point value, Point other)
+        => Math.Abs(value.X - other.X) + Math.Abs(value.Y - other.Y);
+}

--- a/src/AdventOfCode/Puzzles/Y2016/Day01.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day01.cs
@@ -82,7 +82,7 @@ public sealed class Day01 : Puzzle
             }
         }
 
-        return position.ManhattanDistance(Point.Empty);
+        return position.ManhattanDistance();
     }
 
     /// <inheritdoc />

--- a/src/AdventOfCode/Puzzles/Y2016/Day01.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day01.cs
@@ -82,7 +82,7 @@ public sealed class Day01 : Puzzle
             }
         }
 
-        return Math.Abs(position.X) + Math.Abs(position.Y);
+        return position.ManhattanDistance(Point.Empty);
     }
 
     /// <inheritdoc />

--- a/src/AdventOfCode/Puzzles/Y2016/Day13.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day13.cs
@@ -147,10 +147,7 @@ public sealed class Day13 : Puzzle
             maze,
             start,
             goal,
-            ManhattanDistance);
-
-        static double ManhattanDistance(Point a, Point b)
-            => Math.Abs(a.X - b.X) + Math.Abs(a.Y - b.Y);
+            (x, y) => x.ManhattanDistance(y));
     }
 
     private sealed class Maze : SquareGrid

--- a/src/AdventOfCode/Puzzles/Y2016/Day13.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day13.cs
@@ -104,7 +104,7 @@ public sealed class Day13 : Puzzle
     /// </returns>
     private static SquareGrid BuildMaze(int width, int height, int seed)
     {
-        var maze = new SquareGrid(width, height);
+        var maze = new Maze(width, height);
 
         for (int i = 0; i < maze.Width; i++)
         {
@@ -112,7 +112,7 @@ public sealed class Day13 : Puzzle
             {
                 if (IsWall(seed, i, j))
                 {
-                    maze.Walls.Add(new(i, j));
+                    maze.Borders.Add(new(i, j));
                 }
             }
         }
@@ -151,5 +151,16 @@ public sealed class Day13 : Puzzle
 
         static double ManhattanDistance(Point a, Point b)
             => Math.Abs(a.X - b.X) + Math.Abs(a.Y - b.Y);
+    }
+
+    private sealed class Maze : SquareGrid
+    {
+        public Maze(int width, int height)
+            : base(width, height)
+        {
+        }
+
+        public override double Cost(Point a, Point b)
+            => Locations.Contains(b) ? 5 : 1;
     }
 }

--- a/src/AdventOfCode/Puzzles/Y2016/Day24.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day24.cs
@@ -152,6 +152,6 @@ public sealed class Day24 : Puzzle
         }
 
         public override double Cost(Point a, Point b)
-            => Math.Abs(a.X - b.X) + Math.Abs(a.Y - b.Y);
+            => a.ManhattanDistance(b);
     }
 }

--- a/src/AdventOfCode/Puzzles/Y2016/Day24.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day24.cs
@@ -50,7 +50,7 @@ public sealed class Day24 : Puzzle
                     break;
                 }
 
-                costs[(b, a)] = costs[(a, b)] = PathFinding.AStar(maze, a, b, ManhattanDistance);
+                costs[(b, a)] = costs[(a, b)] = PathFinding.AStar(maze, a, b, (a, b) => maze.Cost(a, b));
             }
         }
 
@@ -83,9 +83,6 @@ public sealed class Day24 : Puzzle
         }
 
         return (int)minimumCost;
-
-        static double ManhattanDistance(Point a, Point b)
-            => Math.Abs(a.X - b.X) + Math.Abs(a.Y - b.Y);
     }
 
     /// <inheritdoc />
@@ -119,7 +116,7 @@ public sealed class Day24 : Puzzle
     /// </returns>
     private static (SquareGrid Maze, Point Origin, IList<Point> Goals) BuildMaze(IList<string> layout)
     {
-        var maze = new SquareGrid(layout[0].Length, layout.Count);
+        var maze = new Maze(layout[0].Length, layout.Count);
         var origin = Point.Empty;
         var waypoints = new List<Point>();
 
@@ -131,19 +128,30 @@ public sealed class Day24 : Puzzle
 
                 if (content == '#')
                 {
-                    maze.Walls.Add(new Point(x, y));
+                    maze.Borders.Add(new(x, y));
                 }
                 else if (content == '0')
                 {
-                    origin = new Point(x, y);
+                    origin = new(x, y);
                 }
                 else if (content != '.')
                 {
-                    waypoints.Add(new Point(x, y));
+                    waypoints.Add(new(x, y));
                 }
             }
         }
 
         return (maze, origin, waypoints);
+    }
+
+    private sealed class Maze : SquareGrid
+    {
+        public Maze(int width, int height)
+            : base(width, height)
+        {
+        }
+
+        public override double Cost(Point a, Point b)
+            => Math.Abs(a.X - b.X) + Math.Abs(a.Y - b.Y);
     }
 }

--- a/src/AdventOfCode/Puzzles/Y2017/Day03.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day03.cs
@@ -100,7 +100,7 @@ public sealed class Day03 : Puzzle
             position += Down;
         }
 
-        return position.ManhattanDistance(Point.Empty);
+        return position.ManhattanDistance();
     }
 
     /// <summary>

--- a/src/AdventOfCode/Puzzles/Y2017/Day03.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day03.cs
@@ -100,9 +100,7 @@ public sealed class Day03 : Puzzle
             position += Down;
         }
 
-        int manhattanDistance = Math.Abs(position.X) + Math.Abs(position.Y);
-
-        return manhattanDistance;
+        return position.ManhattanDistance(Point.Empty);
     }
 
     /// <summary>

--- a/src/AdventOfCode/Puzzles/Y2017/Day03.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day03.cs
@@ -100,9 +100,9 @@ public sealed class Day03 : Puzzle
             position += Down;
         }
 
-        int manhattenDistance = Math.Abs(position.X) + Math.Abs(position.Y);
+        int manhattanDistance = Math.Abs(position.X) + Math.Abs(position.Y);
 
-        return manhattenDistance;
+        return manhattanDistance;
     }
 
     /// <summary>

--- a/src/AdventOfCode/Puzzles/Y2018/Day06.cs
+++ b/src/AdventOfCode/Puzzles/Y2018/Day06.cs
@@ -64,7 +64,7 @@ public sealed class Day06 : Puzzle
                 // Get the Manhattan distance each coordinate is from this point
                 var distances = points
                     .Select((p) => new { Point = p, Distance = p - new Size(x, y) })
-                    .Select((p) => new { Point = p.Point, Distance = Math.Abs(p.Distance.X) + Math.Abs(p.Distance.Y) })
+                    .Select((p) => new { Point = p.Point, Distance = p.Distance.ManhattanDistance(Point.Empty) })
                     .OrderBy((p) => p.Distance)
                     .ToList();
 

--- a/src/AdventOfCode/Puzzles/Y2018/Day06.cs
+++ b/src/AdventOfCode/Puzzles/Y2018/Day06.cs
@@ -64,7 +64,7 @@ public sealed class Day06 : Puzzle
                 // Get the Manhattan distance each coordinate is from this point
                 var distances = points
                     .Select((p) => new { Point = p, Distance = p - new Size(x, y) })
-                    .Select((p) => new { Point = p.Point, Distance = p.Distance.ManhattanDistance(Point.Empty) })
+                    .Select((p) => new { Point = p.Point, Distance = p.Distance.ManhattanDistance() })
                     .OrderBy((p) => p.Distance)
                     .ToList();
 

--- a/src/AdventOfCode/Puzzles/Y2019/Day03.cs
+++ b/src/AdventOfCode/Puzzles/Y2019/Day03.cs
@@ -116,7 +116,7 @@ public sealed class Day03 : Puzzle
 
         int manhattanDistance = intersections
             .Skip(1)
-            .Min((p) => Math.Abs(p.X) + Math.Abs(p.Y));
+            .Min((p) => p.ManhattanDistance(Point.Empty));
 
         int minimumSteps = stepsToIntersection
             .Where((p) => p.Key != default && intersections.Contains(p.Key))

--- a/src/AdventOfCode/Puzzles/Y2019/Day03.cs
+++ b/src/AdventOfCode/Puzzles/Y2019/Day03.cs
@@ -116,7 +116,7 @@ public sealed class Day03 : Puzzle
 
         int manhattanDistance = intersections
             .Skip(1)
-            .Min((p) => p.ManhattanDistance(Point.Empty));
+            .Min((p) => p.ManhattanDistance());
 
         int minimumSteps = stepsToIntersection
             .Where((p) => p.Key != default && intersections.Contains(p.Key))

--- a/src/AdventOfCode/Puzzles/Y2019/Day03.cs
+++ b/src/AdventOfCode/Puzzles/Y2019/Day03.cs
@@ -99,14 +99,14 @@ public sealed class Day03 : Puzzle
 
                 for (int j = 0; j < Math.Abs(deltaX); j++, steps++)
                 {
-                    MarkWire(new Point(x + (j * sign), y), (Wires)(i + 1), steps);
+                    MarkWire(new(x + (j * sign), y), (Wires)(i + 1), steps);
                 }
 
                 sign = Math.Sign(deltaY);
 
                 for (int j = 0; j < Math.Abs(deltaY); j++, steps++)
                 {
-                    MarkWire(new Point(x, y + (j * sign)), (Wires)(i + 1), steps);
+                    MarkWire(new(x, y + (j * sign)), (Wires)(i + 1), steps);
                 }
 
                 x += deltaX;

--- a/src/AdventOfCode/Puzzles/Y2020/Day12.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day12.cs
@@ -83,7 +83,7 @@ public sealed class Day12 : Puzzle
             }
         }
 
-        return ship.ManhattanDistance(Point.Empty);
+        return ship.ManhattanDistance();
     }
 
     /// <summary>
@@ -149,7 +149,7 @@ public sealed class Day12 : Puzzle
             }
         }
 
-        return ship.ManhattanDistance(Point.Empty);
+        return ship.ManhattanDistance();
     }
 
     /// <inheritdoc />

--- a/src/AdventOfCode/Puzzles/Y2020/Day12.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day12.cs
@@ -83,7 +83,7 @@ public sealed class Day12 : Puzzle
             }
         }
 
-        return Math.Abs(ship.X) + Math.Abs(ship.Y);
+        return ship.ManhattanDistance(Point.Empty);
     }
 
     /// <summary>
@@ -149,7 +149,7 @@ public sealed class Day12 : Puzzle
             }
         }
 
-        return Math.Abs(ship.X) + Math.Abs(ship.Y);
+        return ship.ManhattanDistance(Point.Empty);
     }
 
     /// <inheritdoc />

--- a/src/AdventOfCode/Puzzles/Y2021/Day09.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day09.cs
@@ -46,7 +46,7 @@ public sealed class Day09 : Puzzle
             }
         }
 
-        var basins = new SquareGrid(width, height);
+        var basins = new Heightmap(width, height);
 
         foreach ((var point, int value) in heights)
         {
@@ -54,17 +54,17 @@ public sealed class Day09 : Puzzle
             // so is effectively the wall/frontier to it.
             if (value == 9)
             {
-                basins.Walls.Add(point);
+                basins.Borders.Add(point);
             }
             else
             {
-                basins.Forests.Add(point);
+                basins.Locations.Add(point);
             }
         }
 
         var lowPoints = new Dictionary<Point, int>();
 
-        foreach (Point point in basins.Forests)
+        foreach (Point point in basins.Locations)
         {
             int lows = 0;
             int neighbors = 0;
@@ -133,5 +133,15 @@ public sealed class Day09 : Puzzle
         }
 
         return PuzzleResult.Create(SumOfRiskLevels, AreaOfThreeLargestBasins);
+    }
+
+    private sealed class Heightmap : SquareGrid
+    {
+        public Heightmap(int width, int height)
+            : base(width, height)
+        {
+        }
+
+        public override double Cost(Point a, Point b) => 1;
     }
 }

--- a/src/AdventOfCode/SquareGrid.cs
+++ b/src/AdventOfCode/SquareGrid.cs
@@ -11,7 +11,7 @@ namespace MartinCostello.AdventOfCode;
 /// <remarks>
 /// Based on <c>https://www.redblobgames.com/pathfinding/a-star/implementation.html</c>.
 /// </remarks>
-public sealed class SquareGrid : IWeightedGraph<Point>
+public abstract class SquareGrid : IWeightedGraph<Point>
 {
     /// <summary>
     /// The valid vectors of movement around the grid.
@@ -29,7 +29,7 @@ public sealed class SquareGrid : IWeightedGraph<Point>
     /// </summary>
     /// <param name="width">The width of the grid.</param>
     /// <param name="height">The height of the grid.</param>
-    public SquareGrid(int width, int height)
+    protected SquareGrid(int width, int height)
     {
         Width = width;
         Height = height;
@@ -46,14 +46,14 @@ public sealed class SquareGrid : IWeightedGraph<Point>
     public int Width { get; private set; }
 
     /// <summary>
-    /// Gets the forests within the grid.
+    /// Gets the locations within the grid.
     /// </summary>
-    public HashSet<Point> Forests { get; } = new HashSet<Point>();
+    public HashSet<Point> Locations { get; } = new HashSet<Point>();
 
     /// <summary>
-    /// Gets the walls within the grid.
+    /// Gets the borders within the grid.
     /// </summary>
-    public HashSet<Point> Walls { get; } = new HashSet<Point>();
+    public HashSet<Point> Borders { get; } = new HashSet<Point>();
 
     /// <summary>
     /// Returns whether the specified point is in the bounds of the grid.
@@ -71,10 +71,10 @@ public sealed class SquareGrid : IWeightedGraph<Point>
     /// <returns>
     /// <see langword="true"/> if <paramref name="id"/> is passable; otherwise <see langword="false"/>.
     /// </returns>
-    public bool IsPassable(Point id) => !Walls.Contains(id);
+    public bool IsPassable(Point id) => !Borders.Contains(id);
 
     /// <inheritdoc/>
-    public double Cost(Point a, Point b) => Forests.Contains(b) ? 5 : 1;
+    public abstract double Cost(Point a, Point b);
 
     /// <inheritdoc/>
     public IEnumerable<Point> Neighbors(Point id)


### PR DESCRIPTION
* Remove the implementation details for some puzzles from `SquareGrid` and make its terminology more generic.
* Add an extension method to compute the Manhattan Distance between one or two points.
