### PR TITLE
Improve performance

### DIFF
--- a/src/AdventOfCode/Puzzles/Y2021/Day12.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day12.cs
@@ -30,7 +30,7 @@ public sealed class Day12 : Puzzle
     /// </returns>
     public static int Navigate(IList<string> nodes, int smallCaveVisitLimit)
     {
-        var caves = new CaveSystem();
+        var caves = new Graph<string>();
 
         foreach (string node in nodes)
         {
@@ -68,15 +68,15 @@ public sealed class Day12 : Puzzle
         return PuzzleResult.Create(Count1, Count2);
     }
 
-    private static int CountPaths(CaveSystem caves, int smallCaveVisitLimit)
+    private static int CountPaths(Graph<string> graph, int smallCaveVisitLimit)
     {
-        var visited = caves.Edges.ToDictionary((p) => p.Key, (_) => 0);
+        var visited = graph.Edges.ToDictionary((p) => p.Key, (_) => 0);
         bool allowOneDoubleVisit = smallCaveVisitLimit == 2;
 
-        return CountPaths(caves, "start", "end", visited, allowOneDoubleVisit);
+        return CountPaths(graph, "start", "end", visited, allowOneDoubleVisit);
 
         static int CountPaths(
-            CaveSystem caves,
+            Graph<string> graph,
             string current,
             string goal,
             Dictionary<string, int> visited,
@@ -91,7 +91,7 @@ public sealed class Day12 : Puzzle
 
             int count = 0;
 
-            foreach (string next in caves.Neighbors(current))
+            foreach (string next in graph.Neighbors(current))
             {
                 // Never return to the first cave
                 if (string.Equals(next, "start", StringComparison.Ordinal))
@@ -103,7 +103,7 @@ public sealed class Day12 : Puzzle
 
                 if (isUpper)
                 {
-                    count += CountPaths(caves, next, goal, visited, allowOneDoubleVisit);
+                    count += CountPaths(graph, next, goal, visited, allowOneDoubleVisit);
                 }
                 else
                 {
@@ -111,11 +111,11 @@ public sealed class Day12 : Puzzle
 
                     if (visits < 1)
                     {
-                        count += CountPaths(caves, next, goal, visited, allowOneDoubleVisit);
+                        count += CountPaths(graph, next, goal, visited, allowOneDoubleVisit);
                     }
                     else if (allowOneDoubleVisit)
                     {
-                        count += CountPaths(caves, next, goal, visited, false);
+                        count += CountPaths(graph, next, goal, visited, false);
                     }
                 }
             }
@@ -124,13 +124,5 @@ public sealed class Day12 : Puzzle
 
             return count;
         }
-    }
-
-    private class CaveSystem : Graph<string>, IWeightedGraph<string>
-    {
-        public double Cost(string a, string b) =>
-            char.IsUpper(b[0]) ? double.PositiveInfinity : 1;
-
-        IEnumerable<string> IWeightedGraph<string>.Neighbors(string id) => Neighbors(id);
     }
 }

--- a/src/AdventOfCode/Puzzles/Y2021/Day12.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day12.cs
@@ -70,25 +70,24 @@ public sealed class Day12 : Puzzle
 
     private static int CountPaths(CaveSystem caves, int smallCaveVisitLimit)
     {
-        var visited = new Dictionary<string, int>(caves.Edges.Count);
+        var visited = caves.Edges.ToDictionary((p) => p.Key, (_) => 0);
         bool allowOneDoubleVisit = smallCaveVisitLimit == 2;
 
-        return CountPaths(caves, "start", "end", visited, ref allowOneDoubleVisit);
+        return CountPaths(caves, "start", "end", visited, allowOneDoubleVisit);
 
         static int CountPaths(
             CaveSystem caves,
             string current,
             string goal,
             Dictionary<string, int> visited,
-            ref bool allowOneDoubleVisit)
+            bool allowOneDoubleVisit)
         {
-            visited.AddOrIncrement(current, 1);
-
             if (current == goal)
             {
-                visited.Remove(current);
                 return 1;
             }
+
+            visited[current]++;
 
             int count = 0;
 
@@ -100,27 +99,23 @@ public sealed class Day12 : Puzzle
                     continue;
                 }
 
-                bool isUpper = string.Equals(next, next.ToUpperInvariant(), StringComparison.Ordinal);
+                bool isUpper = char.IsUpper(next[0]);
 
                 if (isUpper)
                 {
-                    count += CountPaths(caves, next, goal, visited, ref allowOneDoubleVisit);
+                    count += CountPaths(caves, next, goal, visited, allowOneDoubleVisit);
                 }
                 else
                 {
-                    int visits = visited.GetValueOrDefault(next);
+                    int visits = visited[next];
 
                     if (visits < 1)
                     {
-                        count += CountPaths(caves, next, goal, visited, ref allowOneDoubleVisit);
+                        count += CountPaths(caves, next, goal, visited, allowOneDoubleVisit);
                     }
                     else if (allowOneDoubleVisit)
                     {
-                        allowOneDoubleVisit = false;
-
-                        count += CountPaths(caves, next, goal, visited, ref allowOneDoubleVisit);
-
-                        allowOneDoubleVisit = true;
+                        count += CountPaths(caves, next, goal, visited, false);
                     }
                 }
             }
@@ -134,7 +129,7 @@ public sealed class Day12 : Puzzle
     private class CaveSystem : Graph<string>, IWeightedGraph<string>
     {
         public double Cost(string a, string b) =>
-            string.Equals(b.ToUpperInvariant(), b, StringComparison.Ordinal) ? double.PositiveInfinity : 1;
+            char.IsUpper(b[0]) ? double.PositiveInfinity : 1;
 
         IEnumerable<string> IWeightedGraph<string>.Neighbors(string id) => Neighbors(id);
     }


### PR DESCRIPTION
Improve the performance of the solution to day 12 for 2021.

## Before

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1348 (21H1/May2021Update)
Intel Core i9-9980HK CPU 2.40GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.100
  [Host]     : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
  DefaultJob : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT


```
| Method |    input |     Mean |   Error |  StdDev |     Gen 0 | Allocated |
|------- |--------- |---------:|--------:|--------:|----------:|----------:|
|  Solve | Y2021-12 | 173.3 ms | 3.36 ms | 3.45 ms | 8333.3333 |     68 MB |

## After

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1348 (21H1/May2021Update)
Intel Core i9-9980HK CPU 2.40GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.100
  [Host]     : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
  DefaultJob : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT


```
| Method |    input |     Mean |   Error |  StdDev |     Gen 0 | Allocated |
|------- |--------- |---------:|--------:|--------:|----------:|----------:|
|  Solve | Y2021-12 | 107.7 ms | 2.13 ms | 1.99 ms | 2400.0000 |     19 MB |
