### PR TITLE
Remove ToList() call

### DIFF
--- a/src/AdventOfCode/Puzzles/Y2021/Day23.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day23.cs
@@ -272,7 +272,7 @@ public sealed class Day23 : Puzzle
                 });
             }
 
-            return result.ToList();
+            return result;
         }
 
         private static string Move(string hallway, char moved, int index)


### PR DESCRIPTION
Remove redundant `ToList()` call on a `List<T>`.

