### PR TITLE
Un-hardcode input for 2015 day 21

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "terminal.integrated.defaultProfile.linux": "pwsh",
+  "terminal.integrated.defaultProfile.osx": "pwsh",
+  "terminal.integrated.defaultProfile.windows": "PowerShell"
+}

--- a/AdventOfCode.sln
+++ b/AdventOfCode.sln
@@ -53,6 +53,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".vscode", ".vscode", "{2B9D
 	ProjectSection(SolutionItems) = preProject
 		.vscode\extensions.json = .vscode\extensions.json
 		.vscode\launch.json = .vscode\launch.json
+		.vscode\settings.json = .vscode\settings.json
 		.vscode\tasks.json = .vscode\tasks.json
 	EndProjectSection
 EndProject

--- a/src/AdventOfCode/Input/Y2015/Day21/input.txt
+++ b/src/AdventOfCode/Input/Y2015/Day21/input.txt
@@ -1,0 +1,3 @@
+Hit Points: 104
+Damage: 8
+Armor: 1

--- a/src/AdventOfCode/PuzzlesApi.cs
+++ b/src/AdventOfCode/PuzzlesApi.cs
@@ -88,12 +88,12 @@ internal static partial class PuzzlesApi
 
             if (metadata.RequiresData)
             {
-                if (!form.TryGetValue("resource", out var resource))
+                if (form.Files["resource"] is not { } resource)
                 {
                     return Results.Problem("No puzzle resource provided.", statusCode: StatusCodes.Status400BadRequest);
                 }
 
-                puzzle.Resource = new MemoryStream(Encoding.UTF8.GetBytes(resource));
+                puzzle.Resource = resource.OpenReadStream();
             }
 
             if (form.TryGetValue("arguments", out var values))

--- a/src/AdventOfCode/scripts/ts/view/Solver.ts
+++ b/src/AdventOfCode/scripts/ts/view/Solver.ts
@@ -199,7 +199,7 @@ export class Solver {
                 this.solve(url, form);
             };
 
-            form.append('resource', file);
+            form.append('resource', file, 'input.txt');
         } else {
             await this.solve(url, form);
         }

--- a/tests/AdventOfCode.Tests/Api/ApiTests.cs
+++ b/tests/AdventOfCode.Tests/Api/ApiTests.cs
@@ -198,7 +198,7 @@ public class ApiTests : IntegrationTest
         if (testCase.SendResource)
         {
 #pragma warning disable CA2000
-            content.Add(new StringContent(GetPuzzleInput(year, day)), "resource");
+            content.Add(new StringContent(GetPuzzleInput(year, day)), "resource", "input.txt");
 #pragma warning restore CA2000
         }
 

--- a/tests/AdventOfCode.Tests/Api/ApiTests.cs
+++ b/tests/AdventOfCode.Tests/Api/ApiTests.cs
@@ -54,7 +54,7 @@ public class ApiTests : IntegrationTest
     [PuzzleData(2015, 19, new[] { "fabricate" }, 207, Skip = "Too slow.")]
     [PuzzleData(2015, 20, new[] { "34000000" }, 786240)]
     [PuzzleData(2015, 20, new[] { "34000000", "50" }, 831600)]
-    [PuzzleData(2015, 21, 148, 78, SendResource = false)]
+    [PuzzleData(2015, 21, 148, 78)]
     [PuzzleData(2015, 22, new[] { "easy" }, 953)]
     [PuzzleData(2015, 22, new[] { "hard" }, 1289)]
     [PuzzleData(2015, 23, 1u, 170u, SendResource = true)]


### PR DESCRIPTION
* Remove hard-coded boss stats for day 21 of 2015 and parse from input instead.
* Guard against an infinite loop if the boss stats are malformed.
* Upload the files as actual files, rather than files inside named parameters, which also simplifies the code to read them server-side.
* Set the default shell for Visual Studio Code to be PowerShell Core.

Relates to #426.
