### PR TITLE
Remove -InstallDotNetSdkLocally

### DIFF
--- a/benchmark.ps1
+++ b/benchmark.ps1
@@ -1,4 +1,8 @@
-#! /usr/bin/pwsh
+#! /usr/bin/env pwsh
+
+#Requires -PSEdition Core
+#Requires -Version 7
+
 param(
     [Parameter(Mandatory = $false)][string] $Configuration = "Release",
     [Parameter(Mandatory = $false)][string] $Framework = "net6.0"

--- a/benchmark.ps1
+++ b/benchmark.ps1
@@ -34,7 +34,7 @@ else {
 
 if ($installDotNetSdk -eq $true) {
     $env:DOTNET_INSTALL_DIR = Join-Path "$(Convert-Path "$PSScriptRoot")" ".dotnet"
-    $sdkPath = Join-Path $env:DOTNET_INSTALL_DIR "sdk\$dotnetVersion"
+    $sdkPath = Join-Path $env:DOTNET_INSTALL_DIR "sdk" $dotnetVersion
 
     if (!(Test-Path $sdkPath)) {
         if (!(Test-Path $env:DOTNET_INSTALL_DIR)) {
@@ -65,7 +65,7 @@ if ($installDotNetSdk -eq $true) {
     $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
 }
 
-$benchmarks = (Join-Path $solutionPath "tests\AdventOfCode.Benchmarks\AdventOfCode.Benchmarks.csproj")
+$benchmarks = (Join-Path $solutionPath "tests" "AdventOfCode.Benchmarks" "AdventOfCode.Benchmarks.csproj")
 
 Write-Host "Running benchmarks..." -ForegroundColor Green
 

--- a/benchmark.yml
+++ b/benchmark.yml
@@ -1,7 +1,7 @@
 components:
   app:
     script: |
-      pwsh build.ps1 -InstallDotNetSdkLocally -SkipTests
+      pwsh build.ps1 -SkipTests
     arguments: ""
 
 defaults: --config ./crank.yml

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,8 @@
-#! /usr/bin/pwsh
+#! /usr/bin/env pwsh
+
+#Requires -PSEdition Core
+#Requires -Version 7
+
 param(
     [Parameter(Mandatory = $false)][string] $Configuration = "Release",
     [Parameter(Mandatory = $false)][string] $VersionSuffix = "",


### PR DESCRIPTION
Remove `-InstallDotNetSdkLocally` as crank should now use `dotnet` from the path, rather than from `.dotnet`.
