### PR TITLE
Skip publishing

### DIFF
--- a/benchmark.yml
+++ b/benchmark.yml
@@ -1,7 +1,7 @@
 components:
   app:
     script: |
-      pwsh build.ps1 -SkipTests
+      pwsh build.ps1 -SkipPublish -SkipTests
     arguments: ""
 
 defaults: --config ./crank.yml


### PR DESCRIPTION
Skip publishing when running the benchmarks, otherwise it's built twice.
