### PR TITLE
Remove DOTNET_ROLL_FORWARD

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -111,6 +111,5 @@ jobs:
       env:
         DOTNET_CLI_TELEMETRY_OPTOUT: true
         DOTNET_NOLOGO: true
-        DOTNET_ROLL_FORWARD: Major
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
         NUGET_XMLDOC_MODE: skip


### PR DESCRIPTION
.NET 6 is now supported by crank.
