### PR TITLE
Fix runtime error on deployment

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="4.5.3" />
     <PackageVersion Include="Shouldly" Version="4.0.3" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.376" />
-    <PackageVersion Include="System.Runtime.Experimental" Version="6.0.1" />
+    <PackageVersion Include="System.Runtime.Experimental" Version="6.0.2-mauipre.1.22054.8" />
     <PackageVersion Include="xunit" Version="2.4.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />


### PR DESCRIPTION
Fix System.IO.FileLoadException by using System.Runtime.Experimental `6.0.2-mauipre.1.22054.8`.

```
Unhandled exception. System.IO.FileLoadException: Could not load file or assembly 'System.Runtime, Version=6.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The located assembly's manifest definition does not match the assembly reference. (0x80131040)
File name: 'System.Runtime, Version=6.0.0.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
```
