### PR TITLE
Revert System.Runtime.Experimental

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -50,4 +50,16 @@
     <Using Include="Xunit" />
     <Using Include="Xunit.Abstractions" />
   </ItemGroup>
+  <!--
+    HACK Workaround for https://github.com/dotnet/runtime/issues/65018
+  -->
+  <Target Name="RemoveSystemRuntimeFromRefPack"
+          BeforeTargets="_HandlePackageFileConflicts"
+          Condition="'@(Reference -> WithMetadataValue('NugetPackageId', 'System.Runtime.Experimental'))' != ''">
+    <ItemGroup>
+      <Reference Remove="@(Reference)"
+                 Condition="$([System.String]::Copy(%(Reference.Identity)).Contains('System.Runtime.dll')) and
+                            '%(Reference.NuGetPackageId)' == 'Microsoft.NETCore.App.Ref'" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="4.5.3" />
     <PackageVersion Include="Shouldly" Version="4.0.3" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.376" />
-    <PackageVersion Include="System.Runtime.Experimental" Version="6.0.2-mauipre.1.22054.8" />
+    <PackageVersion Include="System.Runtime.Experimental" Version="6.0.0" />
     <PackageVersion Include="xunit" Version="2.4.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />


### PR DESCRIPTION
Revert to the `6.0.0` release of `System.Runtime.Experimental` and re-apply the workaround for `INumber<T>` until dotnet/runtime#65018 is resolved.
