### PR TITLE
Update Lambda Test Server and fix AWS deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,18 +181,18 @@ jobs:
     - name: Deploy CloudFormation Template
       shell: pwsh
       run: |
+        $description = "Deploy build ${{ github.run_number }} to AWS via GitHub Actions"
         $configPath = Join-Path $pwd "aws-lambda-tools-defaults.json"
         $packagePath = Join-Path $pwd "lambda.zip"
-        $config = Get-Content $configPath -Raw | ConvertFrom-Json
-        $config."function-description" = "Deploy build ${{ github.run_number }} to AWS via GitHub Actions"
-        $config | ConvertTo-Json | Set-Content $configPath
         dotnet-lambda `
             deploy-serverless `
             ${{ env.AWS_CLOUDFORMATION_STACK }} `
             --config-file $configPath `
             --disable-interactive true `
             --package $packagePath `
-            --stack-wait true
+            --stack-wait true `
+            --tags "GITHUB_ACTIONS_RUN=${{ github.run_number }}" `
+            --template-substitutions "Description=$description"
 
   test-aws:
     name: test-aws

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,6 +187,7 @@ jobs:
         dotnet-lambda `
             deploy-serverless `
             ${{ env.AWS_CLOUDFORMATION_STACK }} `
+            --cloudformation-role "${{ secrets.AWS_CLOUDFORMATION_ROLE }}" `
             --config-file $configPath `
             --disable-interactive true `
             --package $packagePath `

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.1.1695" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="1.3.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.2.0" />
-    <PackageVersion Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.6.0-beta0445" />
+    <PackageVersion Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.6.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.19.1" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -3,7 +3,6 @@
   <packageSources>
     <clear />
     <add key="local" value=".packages" />
-    <add key="martincostello" value="https://www.myget.org/F/martincostello/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/AdventOfCode.Site/serverless.template
+++ b/src/AdventOfCode.Site/serverless.template
@@ -3,7 +3,7 @@
   "Transform": "AWS::Serverless-2016-10-31",
   "Description": "The Advent of Code as a Service web application running in Amazon Lambda.",
   "Parameters": {},
-    "Outputs": {
+  "Outputs": {
     "ApplicationUrl": {
       "Description": "The endpoint URL for the Prod environment.",
       "Value": {


### PR DESCRIPTION
* Bump to stable version of `MartinCostello.Testing.AwsLambdaTestServer` from NuGet.org.
* Add a CloudFormation role to assume when deploying the stack.
* Fix the description not being applied to the CloudFormation stack.
* Apply tags to resources linking back to the GitHub Actions run number.
