### PR TITLE
Use Except()

### DIFF
--- a/src/AdventOfCode/Maths.cs
+++ b/src/AdventOfCode/Maths.cs
@@ -179,7 +179,7 @@ internal static class Maths
         }
 
         return GetPermutations(collection, count - 1)
-            .SelectMany((p) => collection.Where((r) => !p.Contains(r)), (set, value) => set.Append(value));
+            .SelectMany((p) => collection.Except(p), (set, value) => set.Append(value));
     }
 
     /// <summary>

--- a/src/AdventOfCode/Puzzles/Y2020/Day21.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day21.cs
@@ -70,7 +70,7 @@ public sealed class Day21 : Puzzle
         {
             bool hasUnidentified = false;
 
-            foreach (string allergen in allergenCandidates.Keys.Where((p) => !knownAllergens.Contains(p)))
+            foreach (string allergen in allergenCandidates.Keys.Except(knownAllergens))
             {
                 HashSet<string> candidates = allergenCandidates[allergen];
 


### PR DESCRIPTION
Use `Except()` instead of `first.Where((x) => !second.Contains(x))`.
