### PR TITLE
Fix requests not timing out

### DIFF
--- a/src/AdventOfCode.Site/PuzzlesApi.cs
+++ b/src/AdventOfCode.Site/PuzzlesApi.cs
@@ -104,13 +104,15 @@ internal static partial class PuzzlesApi
 
         var timeout = TimeSpan.FromMinutes(1);
 
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
         var stopwatch = Stopwatch.StartNew();
 
         PuzzleResult solution;
 
         try
         {
-            solution = await puzzle.SolveAsync(arguments, cancellationToken).WaitAsync(timeout, cancellationToken);
+            solution = await puzzle.SolveAsync(arguments, linkedCts.Token).WaitAsync(timeout, linkedCts.Token);
         }
         catch (OperationCanceledException)
         {


### PR DESCRIPTION
- Fix long-running puzzles not being timed out correctly.
- Update Day 19 2021 to check the `CancellationToken` when searching for the solution.
