### PR TITLE
Change Lighthouse access token

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -55,6 +55,7 @@ jobs:
 
     - name: Lighthouse
       uses: foo-software/lighthouse-check-action@v8.0.2
+      id: lighthouse
       with:
         device: 'all'
         gitHubAccessToken: ${{ secrets.LIGHTHOUSE_ACCESS_TOKEN }}
@@ -62,6 +63,16 @@ jobs:
         prCommentEnabled: true
         urls: 'https://localhost:5001'
         wait: true
+
+    - name: Check Lighthouse scores
+      uses: foo-software/lighthouse-check-status-action@v1.0.1
+      with:
+        lighthouseCheckResults: ${{ steps.lighthouse.outputs.lighthouseCheckResults }}
+        minAccessibilityScore: "95"
+        minBestPracticesScore: "100"
+        minPerformanceScore: "85"
+        minProgressiveWebAppScore: "50"
+        minSeoScore: "85"
 
     - name: Publish artifacts
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
- Use an access token that has access to leave reviews from pull requests.
- Set explicit GitHub token permissions.
- Fail workflow if Lighthouse scores regress.
