### PR TITLE
Fix circular dependency

### DIFF
--- a/src/AdventOfCode.Site/gulpfile.js
+++ b/src/AdventOfCode.Site/gulpfile.js
@@ -1,4 +1,4 @@
-/// <binding ProjectOpened='default, watch' />
+/// <binding ProjectOpened='watch' />
 const browserify = require('browserify');
 const buffer = require('vinyl-buffer');
 const eslint = require('gulp-eslint');
@@ -58,5 +58,5 @@ gulp.task('test', function () {
 gulp.task('default', gulp.series('prettier', 'lint', 'build', 'test'));
 
 gulp.task('watch', function () {
-    gulp.watch(glob, gulp.series('default'));
+    gulp.watch(glob, gulp.series('lint', 'build', 'test'));
 });


### PR DESCRIPTION
Fix running `default` causing a circular dependency with `watch` when formatting was run which would make it build (and format) again.
