### PR TITLE
Upgrade to Bootstrap 5

### DIFF
--- a/.github/workflows/update-static-assets.yml
+++ b/.github/workflows/update-static-assets.yml
@@ -1,0 +1,25 @@
+name: update-static-assets
+
+on:
+  schedule:
+    - cron:  '0 5 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-static-assets:
+    name: Update static assets
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Update static assets
+      uses: martincostello/update-static-assets@main
+      if: ${{ github.repository_owner == 'martincostello' }}
+      with:
+        labels: "dependencies"
+        repo-token: ${{ secrets.ACCESS_TOKEN }}
+        user-email: 102549341+costellobot@users.noreply.github.com
+        user-name: costellobot

--- a/AdventOfCode.sln
+++ b/AdventOfCode.sln
@@ -52,6 +52,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\benchmark.yml = .github\workflows\benchmark.yml
 		.github\workflows\build.yml = .github\workflows\build.yml
 		.github\workflows\update-dotnet-sdk.yml = .github\workflows\update-dotnet-sdk.yml
+		.github\workflows\update-static-assets.yml = .github\workflows\update-static-assets.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".vscode", ".vscode", "{2B9D0296-9AAF-4C1E-84C5-3A617D820DDD}"

--- a/src/AdventOfCode.Site/CustomHttpHeadersMiddleware.cs
+++ b/src/AdventOfCode.Site/CustomHttpHeadersMiddleware.cs
@@ -74,7 +74,6 @@ public sealed class CustomHttpHeadersMiddleware
                 context.Response.Headers.Add("Expect-CT", "max-age=1800");
             }
 
-            context.Response.Headers.Add("Feature-Policy", "accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'");
             context.Response.Headers.Add("Permissions-Policy", "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()");
             context.Response.Headers.Add("Referrer-Policy", "no-referrer-when-downgrade");
             context.Response.Headers.Add("X-Content-Type-Options", "nosniff");

--- a/src/AdventOfCode.Site/CustomHttpHeadersMiddleware.cs
+++ b/src/AdventOfCode.Site/CustomHttpHeadersMiddleware.cs
@@ -15,10 +15,10 @@ public sealed class CustomHttpHeadersMiddleware
         new[]
         {
             "default-src 'self'",
-            "script-src 'self' 'nonce-{0}' cdn.jsdelivr.net cdnjs.cloudflare.com",
-            "script-src-elem 'self' 'nonce-{0}' cdn.jsdelivr.net cdnjs.cloudflare.com",
-            "style-src 'self' 'nonce-{0}' cdn.jsdelivr.net cdnjs.cloudflare.com",
-            "style-src-elem 'self' 'nonce-{0}' cdn.jsdelivr.net cdnjs.cloudflare.com",
+            "script-src 'self' 'nonce-{0}' cdnjs.cloudflare.com",
+            "script-src-elem 'self' 'nonce-{0}' cdnjs.cloudflare.com",
+            "style-src 'self' 'nonce-{0}' cdnjs.cloudflare.com",
+            "style-src-elem 'self' 'nonce-{0}' cdnjs.cloudflare.com",
             "img-src 'self'",
             "font-src 'self' cdnjs.cloudflare.com",
             "connect-src 'self'",

--- a/src/AdventOfCode.Site/Pages/Home/Index.cshtml
+++ b/src/AdventOfCode.Site/Pages/Home/Index.cshtml
@@ -24,10 +24,9 @@
             <textarea class="form-control" id="arguments" rows="2"></textarea>
         </div>
         <div class="form-group d-none" id="file-container">
-            <label for="resource">Puzzle input</label>
+            <label class="form-label" for="resource" id="resource-label">Puzzle input file</label>
             <div class="custom-file">
                 <input type="file" class="form-control" id="resource">
-                <label class="form-label" for="resource" id="resource-label">Puzzle input file</label>
             </div>
         </div>
         <button type="submit" class="btn btn-secondary btn-lg mt-2" id="solve">

--- a/src/AdventOfCode.Site/Pages/Home/Index.cshtml
+++ b/src/AdventOfCode.Site/Pages/Home/Index.cshtml
@@ -12,8 +12,7 @@
     <form id="form" action="" class="needs-validation" method="get" novalidate>
         <div class="form-group">
             <label for="year">Year</label>
-            <select class="form-control" id="year" required>
-            </select>
+            <select class="form-control" id="year" required></select>
         </div>
         <div class="form-group">
             <label for="day">Day</label>
@@ -27,11 +26,11 @@
         <div class="form-group d-none" id="file-container">
             <label for="resource">Puzzle input</label>
             <div class="custom-file">
-                <input type="file" class="custom-file-input form-control-file" id="resource">
-                <label class="custom-file-label" for="resource" id="resource-label">Puzzle input file</label>
+                <input type="file" class="form-control" id="resource">
+                <label class="form-label" for="resource" id="resource-label">Puzzle input file</label>
             </div>
         </div>
-        <button type="submit" class="btn btn-secondary btn-lg" id="solve">
+        <button type="submit" class="btn btn-secondary btn-lg mt-2" id="solve">
             <placeholder id="solve-text">Solve!</placeholder>
             <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true" id="spinner"></span>
         </button>

--- a/src/AdventOfCode.Site/Pages/Home/Index.cshtml
+++ b/src/AdventOfCode.Site/Pages/Home/Index.cshtml
@@ -1,9 +1,9 @@
 @page "/"
 @model IndexModel
-<div class="jumbotron">
-    <div class="container">
-        <h1 class="display-4">Advent of Code as a Service</h1>
-        <p class="lead">
+<div class="p-5 mt-2 mb-4 rounded-3 border">
+    <div class="container-fluid py-5">
+        <h1 class="display-5 fw-bold">Advent of Code as a Service</h1>
+        <p class="col-md-8 fs-4">
             Solves <a href="https://adventofcode.com/">Advent of Code</a> puzzles using your personal input.
         </p>
     </div>

--- a/src/AdventOfCode.Site/Pages/Shared/_Layout.cshtml
+++ b/src/AdventOfCode.Site/Pages/Shared/_Layout.cshtml
@@ -56,11 +56,11 @@
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
         <a id="link-home" class="navbar-brand" href="~/">@(appName)</a>
-        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#site-navbar" aria-controls="site-navbar" aria-expanded="false" aria-label="Toggle navigation">
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#site-navbar" aria-controls="site-navbar" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="site-navbar">
-            <ul class="navbar-nav mr-auto">
+            <ul class="navbar-nav me-auto">
                 <li class="nav-item">
                     <a id="link-aoc" class="nav-link" href="https://adventofcode.com/" rel="noopener" target="_blank" title="Open Advent of Code">Advent of Code</a>
                 </li>
@@ -77,9 +77,8 @@
             <p>&copy; Martin Costello @DateTimeOffset.UtcNow.Year</p>
         </footer>
     </main>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.1/slate/bootstrap.min.css" integrity="sha512-vcxGhXoYp4V+Px82NLfIO/aoZjAXBnkVDNaII83WBgEe5bfPGD1wgUu9Av3+IzTh3ilPiEie5Zc21hrk84oBUg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.slim.min.js" integrity="sha512-6ORWJX/LrnSjBzwefdNUyLCMTIsGoNP6NftMy2UAm1JBm6PRZCO1d7OHBStWpVFZLO+RerTvqX/Z9mBFfCJZ4A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-fQybjgWLrvvRgtW6bFlB7jaZrFsaBXjsOMm/tB9LTS58ONXgqbR9W8oWht/amnpF" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.2.0/slate/bootstrap.min.css" integrity="sha512-R4B28W0n4tNv17cFGnLJJEjHkpbpKWi2XE+OyqSAkJa43DsAPVxpnjInGES8QGE6AL8kwtjeQ56hY/kYdUkMCQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.0/js/bootstrap.bundle.min.js" integrity="sha512-9GacT4119eY3AcosfWtHMsT5JyZudrexyEVzTBWV3viP/YfB9e2pEy3N7WXL3SV6ASXpTU0vzzSxsbfsuUH4sQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="~/static/js/main.js" asp-append-version="true"></script>
 </body>
 <!--

--- a/src/AdventOfCode.Site/Pages/Shared/_Layout.cshtml
+++ b/src/AdventOfCode.Site/Pages/Shared/_Layout.cshtml
@@ -42,8 +42,6 @@
     <meta name="application-name" content="@(appName)" />
     <link rel="manifest" href="~/manifest.webmanifest" />
     <link rel="shortcut icon" href="~/favicon.png" type="image/x-icon" />
-    <link rel="dns-prefetch" href="//stackpath.bootstrapcdn.com" />
-    <link rel="preconnect" href="//stackpath.bootstrapcdn.com" />
     <script type="text/javascript" nonce="@(Context.Items["csp-hash"])">
         if (self == top) {
             document.documentElement.className = document.documentElement.className.replace(/\bjs-flash\b/, '');

--- a/src/AdventOfCode.Site/wwwroot/error.html
+++ b/src/AdventOfCode.Site/wwwroot/error.html
@@ -32,12 +32,12 @@
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-        <a id="link-home" class="navbar-brand" href="~/">Advent of Code as a Service</a>
-        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#site-navbar" aria-controls="site-navbar" aria-expanded="false" aria-label="Toggle navigation">
+        <a id="link-home" class="navbar-brand" href="/">Advent of Code as a Service</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#site-navbar" aria-controls="site-navbar" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="site-navbar">
-            <ul class="navbar-nav mr-auto">
+            <ul class="navbar-nav me-auto">
                 <li class="nav-item">
                     <a id="link-aoc" class="nav-link" href="https://adventofcode.com/" rel="noopener" target="_blank" title="Open Advent of Code">Advent of Code</a>
                 </li>
@@ -55,8 +55,7 @@
             <p>&copy; Martin Costello 2022</p>
         </footer>
     </main>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.1/slate/bootstrap.min.css" integrity="sha512-vcxGhXoYp4V+Px82NLfIO/aoZjAXBnkVDNaII83WBgEe5bfPGD1wgUu9Av3+IzTh3ilPiEie5Zc21hrk84oBUg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.slim.min.js" integrity="sha512-6ORWJX/LrnSjBzwefdNUyLCMTIsGoNP6NftMy2UAm1JBm6PRZCO1d7OHBStWpVFZLO+RerTvqX/Z9mBFfCJZ4A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-fQybjgWLrvvRgtW6bFlB7jaZrFsaBXjsOMm/tB9LTS58ONXgqbR9W8oWht/amnpF" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.2.0/slate/bootstrap.min.css" integrity="sha512-R4B28W0n4tNv17cFGnLJJEjHkpbpKWi2XE+OyqSAkJa43DsAPVxpnjInGES8QGE6AL8kwtjeQ56hY/kYdUkMCQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.0/js/bootstrap.bundle.min.js" integrity="sha512-9GacT4119eY3AcosfWtHMsT5JyZudrexyEVzTBWV3viP/YfB9e2pEy3N7WXL3SV6ASXpTU0vzzSxsbfsuUH4sQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </body>
 </html>

--- a/src/AdventOfCode.Site/wwwroot/error.html
+++ b/src/AdventOfCode.Site/wwwroot/error.html
@@ -17,10 +17,8 @@
     <meta name="theme-color" content="#000000" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="application-name" content="Advent of Code as a Service" />
-    <link rel="manifest" href="~/manifest.webmanifest" />
-    <link rel="shortcut icon" href="~/favicon.png" type="image/x-icon" />
-    <link rel="dns-prefetch" href="//stackpath.bootstrapcdn.com" />
-    <link rel="preconnect" href="//stackpath.bootstrapcdn.com" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="shortcut icon" href="/favicon.png" type="image/x-icon" />
     <script type="text/javascript">
         if (self == top) {
             document.documentElement.className = document.documentElement.className.replace(/\bjs-flash\b/, '');


### PR DESCRIPTION
- Upgrade from Bootstrap 4 to 5.
- Add a workflow to keep static CDN asserts up-to-date using [martincostello/update-static-assets](https://github.com/martincostello/update-static-assets).
- Remove `Feature-Policy` as it creates Chrome warnings when used with `Permissions-Policy`.
- Remove redundant domains for `stackpath.bootstrapcdn.com` and `cdn.jsdelivr.net`.
