### PR TITLE
Add data to image source

### DIFF
--- a/src/AdventOfCode.Site/CustomHttpHeadersMiddleware.cs
+++ b/src/AdventOfCode.Site/CustomHttpHeadersMiddleware.cs
@@ -19,7 +19,7 @@ public sealed class CustomHttpHeadersMiddleware
             "script-src-elem 'self' 'nonce-{0}' cdnjs.cloudflare.com",
             "style-src 'self' 'nonce-{0}' cdnjs.cloudflare.com",
             "style-src-elem 'self' 'nonce-{0}' cdnjs.cloudflare.com",
-            "img-src 'self'",
+            "img-src 'self' data:",
             "font-src 'self' cdnjs.cloudflare.com",
             "connect-src 'self'",
             "media-src 'none'",


### PR DESCRIPTION
Add `data:` to img-src to resolve Content Security Policy error.
