### PR TITLE
Add a version endpoint

### DIFF
--- a/src/AdventOfCode.Site/Program.cs
+++ b/src/AdventOfCode.Site/Program.cs
@@ -3,6 +3,7 @@
 
 using System.IO.Compression;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using MartinCostello.AdventOfCode;
 using MartinCostello.AdventOfCode.Site;
 using Microsoft.AspNetCore.Http.Json;
@@ -127,7 +128,29 @@ if (app.Environment.IsDevelopment())
        .ExcludeFromDescription();
 }
 
+app.MapGet("/version", () =>
+{
+    var result = new
+    {
+        applicationVersion = GetVersion<ApplicationJsonSerializerContext>(),
+        frameworkDescription = RuntimeInformation.FrameworkDescription,
+        operatingSystem = RuntimeInformation.OSDescription,
+        operatingSystemArchitecture = RuntimeInformation.OSArchitecture.ToString(),
+        processArchitecture = RuntimeInformation.ProcessArchitecture.ToString(),
+        dotnet = new
+        {
+            runtime = GetVersion<object>(),
+            aspNetCore = GetVersion<RequestDelegateFactoryOptions>(),
+        },
+    };
+
+    return Results.Json(result);
+}).AllowAnonymous();
+
 app.Run();
+
+static string GetVersion<T>()
+    => typeof(T).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
 
 namespace MartinCostello.AdventOfCode.Site
 {

--- a/tests/AdventOfCode.Tests/Api/ResourceTests.cs
+++ b/tests/AdventOfCode.Tests/Api/ResourceTests.cs
@@ -4,12 +4,12 @@
 using System.Net;
 using System.Net.Mime;
 
-namespace MartinCostello.AdventOfCode.EndToEnd;
+namespace MartinCostello.AdventOfCode.Api;
 
-public class ResourceTests : EndToEndTest
+public class ResourceTests : IntegrationTest
 {
-    public ResourceTests(SiteFixture fixture)
-        : base(fixture)
+    public ResourceTests(HttpServerFixture fixture, ITestOutputHelper outputHelper)
+        : base(fixture, outputHelper)
     {
     }
 


### PR DESCRIPTION
Add a `/version` endpoint that can be used to demonstrate the runtime environment in which the application is running.
