### PR TITLE
Use Linux for benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   benchmark:
     name: benchmark
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     if: ${{ github.event.repository.fork == false && github.event.issue.pull_request != '' && contains(github.event.comment.body, '/benchmark') }}
 
     steps:


### PR DESCRIPTION
Use Linux for benchmarks instead of Windows.
