### PR TITLE
Cache resources in benchmarks

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageVersion Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.7.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="$(MicrosoftICUICU4CRuntimeVersion)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.28.0" />

--- a/src/AdventOfCode.Console/Program.cs
+++ b/src/AdventOfCode.Console/Program.cs
@@ -41,7 +41,7 @@ Console.CancelKeyPress += (_, e) =>
 };
 
 var logger = new ConsoleLogger();
-var factory = new PuzzleFactory(logger);
+var factory = new PuzzleFactory(NullCache.Instance, logger);
 
 Puzzle puzzle;
 

--- a/src/AdventOfCode.Site/Program.cs
+++ b/src/AdventOfCode.Site/Program.cs
@@ -18,6 +18,7 @@ builder.WebHost.CaptureStartupErrors(true);
 
 builder.WebHost.ConfigureKestrel((p) => p.AddServerHeader = false);
 
+builder.Services.AddSingleton<ICache>((_) => NullCache.Instance);
 builder.Services.AddSingleton<ILogger, WebLogger>();
 
 builder.Services.AddSingleton<PuzzleFactory>();

--- a/src/AdventOfCode/ICache.cs
+++ b/src/AdventOfCode/ICache.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.AdventOfCode;
+
+/// <summary>
+/// Represents a cache.
+/// </summary>
+public interface ICache
+{
+    /// <summary>
+    /// Returns the value associated with the specified key as an asynchronous operation.
+    /// </summary>
+    /// <typeparam name="TItem">The type of the item.</typeparam>
+    /// <param name="key">The key for the item.</param>
+    /// <param name="factory">A delegate to a method to use to create the item.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that represents the asynchronous operation which returns the value associated with the specified key.
+    /// </returns>
+    Task<TItem> GetOrCreateAsync<TItem>(object key, Func<Task<TItem>> factory);
+}

--- a/src/AdventOfCode/NullCache.cs
+++ b/src/AdventOfCode/NullCache.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.AdventOfCode;
+
+/// <summary>
+/// A class representing an <see cref="ICache"/> that does not cache anything. This class cannot be inherited.
+/// </summary>
+public sealed class NullCache : ICache
+{
+    /// <summary>
+    /// The default instance of the <see cref="NullCache"/> class. This field is read-only.
+    /// </summary>
+    public static readonly NullCache Instance = new();
+
+    private NullCache()
+    {
+    }
+
+    /// <inheritdoc/>
+    public Task<TItem> GetOrCreateAsync<TItem>(object key, Func<Task<TItem>> factory)
+        => factory();
+}

--- a/src/AdventOfCode/PuzzleFactory.cs
+++ b/src/AdventOfCode/PuzzleFactory.cs
@@ -9,6 +9,11 @@ namespace MartinCostello.AdventOfCode;
 public class PuzzleFactory
 {
     /// <summary>
+    /// The <see cref="ICache"/> to use. This field is read-only.
+    /// </summary>
+    private readonly ICache _cache;
+
+    /// <summary>
     /// The <see cref="ILogger"/> to use. This field is read-only.
     /// </summary>
     private readonly ILogger _logger;
@@ -16,9 +21,11 @@ public class PuzzleFactory
     /// <summary>
     /// Initializes a new instance of the <see cref="PuzzleFactory"/> class.
     /// </summary>
+    /// <param name="cache">The <see cref="ICache"/> to use.</param>
     /// <param name="logger">The <see cref="ILogger"/> to use.</param>
-    public PuzzleFactory(ILogger logger)
+    public PuzzleFactory(ICache cache, ILogger logger)
     {
+        _cache = cache;
         _logger = logger;
     }
 
@@ -43,6 +50,7 @@ public class PuzzleFactory
             throw new PuzzleException("The year and/or puzzle number specified is invalid.");
         }
 
+        puzzle.Cache = _cache;
         puzzle.Logger = _logger;
         puzzle.Verbose = true;
 

--- a/tests/AdventOfCode.Benchmarks/AdventOfCode.Benchmarks.csproj
+++ b/tests/AdventOfCode.Benchmarks/AdventOfCode.Benchmarks.csproj
@@ -13,5 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
   </ItemGroup>
 </Project>

--- a/tests/AdventOfCode.Benchmarks/PuzzleBenchmarks.cs
+++ b/tests/AdventOfCode.Benchmarks/PuzzleBenchmarks.cs
@@ -255,10 +255,16 @@ public class PuzzleBenchmarks
 
             if (Puzzle is Puzzle puzzle)
             {
-                puzzle.Cache = InMemoryCache.Instance;
+                if (CacheResource)
+                {
+                    puzzle.Cache = InMemoryCache.Instance;
+                }
+
                 puzzle.Logger = NullLogger.Instance;
             }
         }
+
+        public bool CacheResource { get; set; } = true;
 
         public override IPuzzle Puzzle { get; }
 


### PR DESCRIPTION
Add caching for the parsed resources to make the parsing not part of the benchmarks by default.

All other modes (e.g. the console and website) use a no-op fake cache.
