### PR TITLE
.NET 8 preparation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,10 @@ on:
 
 env:
   AWS_CLOUDFORMATION_STACK: adventofcode
-  AWS_LAMBDA_PACKAGE_PATH: ./artifacts/lambda.zip
   AWS_REGION: eu-west-2
   AWS_URL_PROD: https://aoc.martincostello.com/
   AZURE_URL_PROD: https://advent--of--code.azurewebsites.net/
   AZURE_WEBAPP_NAME: advent--of--code
-  AZURE_WEBAPP_PACKAGE_PATH: ./artifacts/publish
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_GENERATE_ASPNET_CERTIFICATE: false
   DOTNET_MULTILEVEL_LOOKUP: 0
@@ -27,6 +25,7 @@ env:
   DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
   FORCE_COLOR: 1
   NUGET_XMLDOC_MODE: skip
+  PUBLISH_RUNTIME: win10-x64
   TERM: xterm
 
 jobs:
@@ -87,7 +86,7 @@ jobs:
 
     - name: Build, test and publish
       shell: pwsh
-      run: ./build.ps1 -Runtime win10-x64
+      run: ./build.ps1 -Runtime "${{ env.PUBLISH_RUNTIME }}"
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
@@ -97,17 +96,19 @@ jobs:
 
     - name: Publish web app
       uses: actions/upload-artifact@v3
-      if: ${{ runner.os == 'Windows' }}
+      if: ${{ runner.os == 'Windows' && success() }}
       with:
         name: webapp
-        path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+        path: ./artifacts/publish
+        if-no-files-found: error
 
     - name: Publish lambda
       uses: actions/upload-artifact@v3
-      if: ${{ runner.os == 'Windows' }}
+      if: ${{ runner.os == 'Windows' && success() }}
       with:
         name: lambda
-        path: ${{ env.AWS_LAMBDA_PACKAGE_PATH }}
+        path: ./artifacts/lambda.zip
+        if-no-files-found: error
 
     - name: Publish screenshots
       uses: actions/upload-artifact@v3

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -87,3 +87,4 @@ jobs:
       with:
         name: lighthouse
         path: ${{ github.workspace }}/artifacts
+        if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.artifacts/
 .DS_Store
 .dotnet
 .dotnetcli

--- a/src/AdventOfCode.Site/AdventOfCode.Site.csproj
+++ b/src/AdventOfCode.Site/AdventOfCode.Site.csproj
@@ -27,7 +27,7 @@
     <ProjectReference Include="..\AdventOfCode\AdventOfCode.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Content Update=".prettierrc.json;package.json;package-lock.json;tsconfig.json" CopyToPublishDirectory="Never" />
+    <Content Update=".prettierrc.json;coverage\**;package.json;package-lock.json;tsconfig.json" CopyToPublishDirectory="Never" />
     <None Remove="scripts\ts\**\*.ts" />
     <TypeScriptCompile Include="scripts\ts\**\*.ts" />
   </ItemGroup>

--- a/tests/AdventOfCode.Tests/BrowserFixture.cs
+++ b/tests/AdventOfCode.Tests/BrowserFixture.cs
@@ -9,6 +9,7 @@ namespace MartinCostello.AdventOfCode;
 public class BrowserFixture
 {
     private const string VideosDirectory = "videos";
+    private const string AssetsDirectory = ".";
 
     public BrowserFixture(ITestOutputHelper outputHelper)
     {
@@ -55,7 +56,7 @@ public class BrowserFixture
             if (IsRunningInGitHubActions)
             {
                 string traceName = GenerateFileName(testName!, browserType, ".zip");
-                string path = Path.Combine("traces", traceName);
+                string path = Path.Combine(AssetsDirectory, "traces", traceName);
 
                 await context.Tracing.StopAsync(new() { Path = path });
 
@@ -133,7 +134,7 @@ public class BrowserFixture
         try
         {
             string fileName = GenerateFileName(testName, browserType, ".png");
-            string path = Path.GetFullPath(Path.Combine("screenshots", fileName));
+            string path = Path.GetFullPath(Path.Combine(AssetsDirectory, "screenshots", fileName));
 
             await page.ScreenshotAsync(new() { Path = path });
 
@@ -168,7 +169,7 @@ public class BrowserFixture
 
             string fileName = GenerateFileName(testName, browserType, extension!);
 
-            string videoDestination = Path.Combine(directory!, fileName);
+            string videoDestination = Path.Combine(AssetsDirectory, directory!, fileName);
 
             File.Move(videoSource, videoDestination);
 


### PR DESCRIPTION
Port changes from #890 to minimise differences:
- Remove some environment variables from build scripts.
- Fail build if certain artifacts cannot be found.
- Ignore missing lighthouse artifacts.
- Exclude JavaScript coverage files from publish.

