### PR TITLE
Remove redundant suppressions

### DIFF
--- a/src/AdventOfCode.Console/Program.cs
+++ b/src/AdventOfCode.Console/Program.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA1812
-#pragma warning disable CA1852
-#pragma warning disable SA1516
-
 using System.Diagnostics;
 using MartinCostello.AdventOfCode;
 

--- a/src/AdventOfCode.Site/Program.cs
+++ b/src/AdventOfCode.Site/Program.cs
@@ -10,9 +10,6 @@ using MartinCostello.AdventOfCode.Site;
 using Microsoft.AspNetCore.ResponseCompression;
 using ILogger = MartinCostello.AdventOfCode.ILogger;
 
-#pragma warning disable CA1812
-#pragma warning disable CA1852
-
 var builder = WebApplication.CreateBuilder(args);
 
 builder.WebHost.CaptureStartupErrors(true);

--- a/tests/AdventOfCode.Benchmarks/Program.cs
+++ b/tests/AdventOfCode.Benchmarks/Program.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA1812
-#pragma warning disable CA1852
-
 using BenchmarkDotNet.Running;
 using MartinCostello.AdventOfCode.Benchmarks;
 


### PR DESCRIPTION
Remove now-redundant suppressions for false-positive code analysis warnings.
