### PR TITLE
Improve performance

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,6 +41,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Using Include="Microsoft.Toolkit.HighPerformance" Condition=" '$(AssemblyName)' != 'AdventOfCode.Resources' " />
+    <Using Include="System.Collections.Immutable" />
     <Using Include="System.Drawing" />
     <Using Include="System.Numerics" />
     <Using Include="System.Globalization" />

--- a/src/AdventOfCode/Puzzle.cs
+++ b/src/AdventOfCode/Puzzle.cs
@@ -170,9 +170,9 @@ public abstract class Puzzle : IPuzzle
     /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> to use.</param>
     /// <returns>
     /// A <see cref="Task{TResult}"/> that represents the asynchronous operation which returns an
-    /// <see cref="IList{T}"/> containing the lines of the resource associated with the puzzle.
+    /// <see cref="List{T}"/> containing the lines of the resource associated with the puzzle.
     /// </returns>
-    protected async Task<IList<string>> ReadResourceAsLinesAsync(CancellationToken cancellationToken = default)
+    protected async Task<List<string>> ReadResourceAsLinesAsync(CancellationToken cancellationToken = default)
     {
         return await Cache.GetOrCreateAsync(this, async () =>
         {
@@ -200,9 +200,9 @@ public abstract class Puzzle : IPuzzle
     /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> to use.</param>
     /// <returns>
     /// A <see cref="Task{TResult}"/> that represents the asynchronous operation which returns an
-    /// <see cref="IList{T}"/> containing the numbers in the resource associated with the puzzle.
+    /// <see cref="List{T}"/> containing the numbers in the resource associated with the puzzle.
     /// </returns>
-    protected async Task<IList<T>> ReadResourceAsNumbersAsync<T>(CancellationToken cancellationToken = default)
+    protected async Task<List<T>> ReadResourceAsNumbersAsync<T>(CancellationToken cancellationToken = default)
         where T : INumber<T>
     {
         return await Cache.GetOrCreateAsync(this, async () =>

--- a/src/AdventOfCode/Puzzles/Y2015/Day05.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day05.cs
@@ -12,7 +12,7 @@ public sealed class Day05 : Puzzle
     /// <summary>
     /// The sequences of characters that are not considered nice. This field is read-only.
     /// </summary>
-    private static readonly string[] NotNiceSequences = { "ab", "cd", "pq", "xy" };
+    private static readonly ImmutableArray<string> NotNiceSequences = new string[] { "ab", "cd", "pq", "xy" }.ToImmutableArray();
 
     /// <summary>
     /// Gets the number of 'nice' strings using version 1 of the rules.

--- a/src/AdventOfCode/Puzzles/Y2015/Day05.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day05.cs
@@ -89,7 +89,7 @@ public sealed class Day05 : Puzzle
     {
         return
             HasLetterThatIsTheBreadOfALetterSandwich(value) &&
-            HasPairOfLettersWithMoreThanOneOccurence(value);
+            HasPairOfLettersWithMoreThanOneOccurrence(value);
     }
 
     /// <summary>
@@ -100,7 +100,7 @@ public sealed class Day05 : Puzzle
     /// <returns>
     /// <see langword="true"/> if <paramref name="value"/> meets the rule; otherwise <see langword="false"/>.
     /// </returns>
-    internal static bool HasPairOfLettersWithMoreThanOneOccurence(ReadOnlySpan<char> value)
+    internal static bool HasPairOfLettersWithMoreThanOneOccurrence(ReadOnlySpan<char> value)
     {
         var letterPairs = new Dictionary<string, List<int>>();
 

--- a/src/AdventOfCode/Puzzles/Y2015/Day07.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day07.cs
@@ -102,7 +102,7 @@ public sealed class Day07 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> instructions = await ReadResourceAsLinesAsync(cancellationToken);
+        var instructions = await ReadResourceAsLinesAsync(cancellationToken);
 
         // Get the wire values for the initial instructions
         Dictionary<string, ushort> values = GetWireValues(instructions);

--- a/src/AdventOfCode/Puzzles/Y2015/Day08.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day08.cs
@@ -134,7 +134,7 @@ public sealed class Day08 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> input = await ReadResourceAsLinesAsync(cancellationToken);
+        var input = await ReadResourceAsLinesAsync(cancellationToken);
 
         int countForCode = input.Sum((p) => p.Length);
         int countInMemory = GetLiteralCharacterCount(input);

--- a/src/AdventOfCode/Puzzles/Y2015/Day13.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day13.cs
@@ -55,7 +55,7 @@ public sealed class Day13 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> potentialHappiness = await ReadResourceAsLinesAsync(cancellationToken);
+        var potentialHappiness = await ReadResourceAsLinesAsync(cancellationToken);
 
         MaximumTotalChangeInHappiness = GetMaximumTotalChangeInHappiness(potentialHappiness);
 

--- a/src/AdventOfCode/Puzzles/Y2015/Day14.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day14.cs
@@ -84,7 +84,7 @@ public sealed class Day14 : Puzzle
             throw new PuzzleException("The time index specified is invalid.");
         }
 
-        IList<string> flightData = await ReadResourceAsLinesAsync(cancellationToken);
+        var flightData = await ReadResourceAsLinesAsync(cancellationToken);
 
         MaximumReindeerDistance = GetMaximumDistanceOfFastestReindeer(flightData, timeIndex);
 

--- a/src/AdventOfCode/Puzzles/Y2015/Day15.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day15.cs
@@ -44,7 +44,7 @@ public sealed class Day15 : Puzzle
         // Get all the permutations which the ingredients could be ordered by
         var ingredientPermutations = Maths.GetPermutations(ingredientProperties.Keys).ToList();
 
-        var recipies = new List<Dictionary<string, int>>(ingredientPermutations.Count * teaspoonPermutations.Count);
+        var recipes = new List<Dictionary<string, int>>(ingredientPermutations.Count * teaspoonPermutations.Count);
 
         // For each permutation of ingredients, create a recipe for each
         // permutation of the number of teaspoons of each one there is.
@@ -61,16 +61,16 @@ public sealed class Day15 : Puzzle
                     recipe[ingredients[i]] = teaspoons[i];
                 }
 
-                recipies.Add(recipe);
+                recipes.Add(recipe);
             }
         }
 
         // Calculate the total score for each possible recipe
         int bestScore = -1;
 
-        for (int i = 0; i < recipies.Count; i++)
+        for (int i = 0; i < recipes.Count; i++)
         {
-            int thisScore = GetRecipeScore(recipies[i], ingredientProperties, calorieCount);
+            int thisScore = GetRecipeScore(recipes[i], ingredientProperties, calorieCount);
 
             if (thisScore > bestScore)
             {

--- a/src/AdventOfCode/Puzzles/Y2015/Day15.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day15.cs
@@ -84,7 +84,7 @@ public sealed class Day15 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> ingredients = await ReadResourceAsLinesAsync(cancellationToken);
+        var ingredients = await ReadResourceAsLinesAsync(cancellationToken);
 
         HighestTotalCookieScore = GetHighestTotalCookieScore(ingredients);
         HighestTotalCookieScoreWith500Calories = GetHighestTotalCookieScore(ingredients, 500);

--- a/src/AdventOfCode/Puzzles/Y2015/Day16.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day16.cs
@@ -104,7 +104,7 @@ public sealed class Day16 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> auntSueMetadata = await ReadResourceAsLinesAsync(cancellationToken);
+        var auntSueMetadata = await ReadResourceAsLinesAsync(cancellationToken);
 
         AuntSueNumber = WhichAuntSueSentTheGift(auntSueMetadata);
         RealAuntSueNumber = WhichAuntSueSentTheGift(auntSueMetadata, compensateForRetroEncabulator: true);

--- a/src/AdventOfCode/Puzzles/Y2015/Day18.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day18.cs
@@ -71,7 +71,7 @@ public sealed class Day18 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> initial = await ReadResourceAsLinesAsync(cancellationToken);
+        var initial = await ReadResourceAsLinesAsync(cancellationToken);
 
         int steps = 100;
 

--- a/src/AdventOfCode/Puzzles/Y2015/Day19.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day19.cs
@@ -125,7 +125,7 @@ public sealed class Day19 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> lines = await ReadResourceAsLinesAsync(cancellationToken);
+        var lines = await ReadResourceAsLinesAsync(cancellationToken);
 
         string molecule = lines[^1];
 

--- a/src/AdventOfCode/Puzzles/Y2015/Day21.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day21.cs
@@ -82,7 +82,7 @@ public sealed class Day21 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> stats = await ReadResourceAsLinesAsync(cancellationToken);
+        var stats = await ReadResourceAsLinesAsync(cancellationToken);
 
         int bossHitPoints = Parse<int>(stats[0].Split(':')[1]);
         int bossDamage = Parse<int>(stats[1].Split(':')[1]);

--- a/src/AdventOfCode/Puzzles/Y2015/Day22.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day22.cs
@@ -47,8 +47,10 @@ public sealed class Day22 : Puzzle
     /// </returns>
     internal static Player Fight(Wizard wizard, Player opponent, string difficulty, Action<string, object[]>? output)
     {
+#pragma warning disable CA1859
         Player attacker = wizard;
         Player defender = opponent;
+#pragma warning restore CA1859
 
         bool isHardDifficulty = string.Equals("HARD", difficulty, StringComparison.OrdinalIgnoreCase);
 
@@ -60,9 +62,7 @@ public sealed class Day22 : Puzzle
 
             if (isHardDifficulty && attacker == wizard)
             {
-                wizard.HitPoints--;
-
-                if (wizard.HitPoints < 1)
+                if (--wizard.HitPoints < 1)
                 {
                     break;
                 }
@@ -75,9 +75,7 @@ public sealed class Day22 : Puzzle
                 attacker.Attack(defender, output);
             }
 
-            Player player = attacker;
-            attacker = defender;
-            defender = player;
+            (attacker, defender) = (defender, attacker);
 
             output?.Invoke(string.Empty, Array.Empty<object>());
         }

--- a/src/AdventOfCode/Puzzles/Y2015/Day23.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day23.cs
@@ -105,7 +105,7 @@ public sealed class Day23 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> instructions = await ReadResourceAsLinesAsync(cancellationToken);
+        var instructions = await ReadResourceAsLinesAsync(cancellationToken);
         uint initialValue = args.Length == 1 ? Parse<uint>(args[0]) : 0;
 
         (A, B) = ProcessInstructions(instructions, initialValue, Logger);

--- a/src/AdventOfCode/Puzzles/Y2015/Day24.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day24.cs
@@ -46,7 +46,7 @@ public sealed class Day24 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<int> weights = await ReadResourceAsNumbersAsync<int>(cancellationToken);
+        var weights = await ReadResourceAsNumbersAsync<int>(cancellationToken);
 
         int compartments = args.Length == 1 ? Parse<int>(args[0]) : 3;
 

--- a/src/AdventOfCode/Puzzles/Y2015/Day24.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day24.cs
@@ -20,7 +20,7 @@ public sealed class Day24 : Puzzle
     /// the ideal configuration for the specified packages and their weights.
     /// </summary>
     /// <param name="compartments">
-    /// The number of comparments in the sleigh.
+    /// The number of compartments in the sleigh.
     /// </param>
     /// <param name="weights">
     /// The weights of the packages to find the quantum entanglement for.

--- a/src/AdventOfCode/Puzzles/Y2016/Day03.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day03.cs
@@ -53,7 +53,7 @@ public sealed class Day03 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> dimensions = await ReadResourceAsLinesAsync(cancellationToken);
+        var dimensions = await ReadResourceAsLinesAsync(cancellationToken);
 
         PossibleTrianglesByRows = GetPossibleTriangleCount(dimensions, readAsColumns: false);
         PossibleTrianglesByColumns = GetPossibleTriangleCount(dimensions, readAsColumns: true);

--- a/src/AdventOfCode/Puzzles/Y2016/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day04.cs
@@ -86,7 +86,7 @@ public sealed class Day04 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> names = await ReadResourceAsLinesAsync(cancellationToken);
+        var names = await ReadResourceAsLinesAsync(cancellationToken);
 
         SumOfSectorIdsOfRealRooms = SumOfRealRoomSectorIds(names);
         SectorIdOfNorthPoleObjectsRoom = GetSectorIdOfNorthPoleObjectsRoom(names);

--- a/src/AdventOfCode/Puzzles/Y2016/Day06.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day06.cs
@@ -55,7 +55,7 @@ public sealed class Day06 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> messages = await ReadResourceAsLinesAsync(cancellationToken);
+        var messages = await ReadResourceAsLinesAsync(cancellationToken);
 
         ErrorCorrectedMessage = DecryptMessage(messages, leastLikely: false);
         ModifiedErrorCorrectedMessage = DecryptMessage(messages, leastLikely: true);

--- a/src/AdventOfCode/Puzzles/Y2016/Day07.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day07.cs
@@ -80,7 +80,7 @@ public sealed class Day07 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> addresses = await ReadResourceAsLinesAsync(cancellationToken);
+        var addresses = await ReadResourceAsLinesAsync(cancellationToken);
 
         IPAddressesSupportingTls = addresses.Count(DoesIPAddressSupportTls);
         IPAddressesSupportingSsl = addresses.Count(DoesIPAddressSupportSsl);

--- a/src/AdventOfCode/Puzzles/Y2016/Day08.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day08.cs
@@ -72,7 +72,7 @@ public sealed class Day08 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> instructions = await ReadResourceAsLinesAsync(cancellationToken);
+        var instructions = await ReadResourceAsLinesAsync(cancellationToken);
 
         (PixelsLit, Code, string visualization) = GetPixelsLit(instructions, width: 50, height: 6, Logger);
 

--- a/src/AdventOfCode/Puzzles/Y2016/Day10.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day10.cs
@@ -79,7 +79,7 @@ public sealed class Day10 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> instructions = await ReadResourceAsLinesAsync(cancellationToken);
+        var instructions = await ReadResourceAsLinesAsync(cancellationToken);
         int[] binsOfInterest = { 0, 1, 2 };
 
         (BotThatCompares61And17Microchips, ProductOfMicrochipsInBins012) = GetBotNumber(instructions, 61, 17, binsOfInterest);

--- a/src/AdventOfCode/Puzzles/Y2016/Day11.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day11.cs
@@ -56,7 +56,7 @@ public sealed class Day11 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> initialState = await ReadResourceAsLinesAsync(cancellationToken);
+        var initialState = await ReadResourceAsLinesAsync(cancellationToken);
 
         MinimumStepsForAssembly = GetMinimumStepsForAssembly(initialState);
 

--- a/src/AdventOfCode/Puzzles/Y2016/Day12.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day12.cs
@@ -176,7 +176,7 @@ public sealed class Day12 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> instructions = await ReadResourceAsLinesAsync(cancellationToken);
+        var instructions = await ReadResourceAsLinesAsync(cancellationToken);
 
         var registers = Process(instructions, initialValueOfC: 0, cancellationToken: cancellationToken);
         ValueInRegisterA = registers['a'];

--- a/src/AdventOfCode/Puzzles/Y2016/Day15.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day15.cs
@@ -53,7 +53,7 @@ public sealed class Day15 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> input = await ReadResourceAsLinesAsync(cancellationToken);
+        var input = await ReadResourceAsLinesAsync(cancellationToken);
 
         string extraDisc = $"Disc #{input.Count + 1} has 11 positions; at time=0, it is at position 0.";
 

--- a/src/AdventOfCode/Puzzles/Y2016/Day20.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day20.cs
@@ -113,7 +113,7 @@ public sealed class Day20 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> ranges = await ReadResourceAsLinesAsync(cancellationToken);
+        var ranges = await ReadResourceAsLinesAsync(cancellationToken);
 
         LowestNonblockedIP = GetLowestNonblockedIP(uint.MaxValue, ranges, out uint count);
         AllowedIPCount = count;

--- a/src/AdventOfCode/Puzzles/Y2016/Day21.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day21.cs
@@ -105,7 +105,7 @@ public sealed class Day21 : Puzzle
         string text = args[0];
         bool reverse = args.Length > 1 && string.Equals(args[1], bool.TrueString, StringComparison.OrdinalIgnoreCase);
 
-        IList<string> instructions = await ReadResourceAsLinesAsync(cancellationToken);
+        var instructions = await ReadResourceAsLinesAsync(cancellationToken);
 
         ScrambledResult = Scramble(text, instructions, reverse);
 

--- a/src/AdventOfCode/Puzzles/Y2016/Day22.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day22.cs
@@ -158,7 +158,7 @@ public sealed class Day22 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> output = await ReadResourceAsLinesAsync(cancellationToken);
+        var output = await ReadResourceAsLinesAsync(cancellationToken);
 
         (ViableNodePairs, MinimumStepsToExtract) = CountViableNodePairs(output, Logger);
 

--- a/src/AdventOfCode/Puzzles/Y2016/Day23.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day23.cs
@@ -19,7 +19,7 @@ public sealed class Day23 : Puzzle
     {
         int input = Parse<int>(args[0]);
 
-        IList<string> instructions = await ReadResourceAsLinesAsync(cancellationToken);
+        var instructions = await ReadResourceAsLinesAsync(cancellationToken);
 
         var registers = Day12.Process(instructions, initialValueOfA: input, cancellationToken: cancellationToken);
         SafeValue = registers['a'];

--- a/src/AdventOfCode/Puzzles/Y2016/Day24.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day24.cs
@@ -90,7 +90,7 @@ public sealed class Day24 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> layout = await ReadResourceAsLinesAsync(cancellationToken);
+        var layout = await ReadResourceAsLinesAsync(cancellationToken);
 
         FewestStepsToVisitAllLocations = GetMinimumStepsToVisitLocations(layout, returnToOrigin: false, cancellationToken);
         FewestStepsToVisitAllLocationsAndReturn = GetMinimumStepsToVisitLocations(layout, returnToOrigin: true, cancellationToken);

--- a/src/AdventOfCode/Puzzles/Y2016/Day25.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day25.cs
@@ -17,7 +17,7 @@ public sealed class Day25 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> instructions = await ReadResourceAsLinesAsync(cancellationToken);
+        var instructions = await ReadResourceAsLinesAsync(cancellationToken);
 
         for (int i = 1; i < int.MaxValue; i++)
         {

--- a/src/AdventOfCode/Puzzles/Y2017/Day02.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day02.cs
@@ -91,7 +91,7 @@ public sealed class Day02 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> lines = await ReadResourceAsLinesAsync(cancellationToken);
+        var lines = await ReadResourceAsLinesAsync(cancellationToken);
         var spreadsheet = ParseSpreadsheet(lines);
 
         ChecksumForDifference = CalculateChecksum(spreadsheet, forEvenlyDivisible: false);

--- a/src/AdventOfCode/Puzzles/Y2017/Day03.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day03.cs
@@ -45,7 +45,7 @@ public sealed class Day03 : Puzzle
         while (currentSquare < square)
         {
             int length = LengthOfRing(ring);
-            int perimeter = PerimiterOfRing(ring);
+            int perimeter = PerimeterOfRing(ring);
 
             // Is the target square in the current ring?
             if (currentSquare + perimeter >= square)
@@ -83,7 +83,7 @@ public sealed class Day03 : Puzzle
             }
 
             // Skip to the next ring
-            currentSquare += PerimiterOfRing(ring++);
+            currentSquare += PerimeterOfRing(ring++);
             position += Right;
             position += Down;
         }
@@ -187,7 +187,7 @@ public sealed class Day03 : Puzzle
     /// <returns>
     /// The perimeter of the ring number specified by <paramref name="ring"/>.
     /// </returns>
-    private static int PerimiterOfRing(int ring) => (2 * LengthOfRing(ring)) + (2 * LengthOfRing(ring - 1));
+    private static int PerimeterOfRing(int ring) => (2 * LengthOfRing(ring)) + (2 * LengthOfRing(ring - 1));
 
     /// <summary>
     /// A class representing values in a grid of two-dimensional memory. This class cannot be inherited.

--- a/src/AdventOfCode/Puzzles/Y2017/Day03.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day03.cs
@@ -197,7 +197,7 @@ public sealed class Day03 : Puzzle
         /// <summary>
         /// An array of offsets that may surround an address in the grid.
         /// </summary>
-        private static readonly Size[] Offsets =
+        private static readonly ImmutableArray<Size> Offsets = new Size[]
         {
             new(0, 1),
             new(1, 1),
@@ -207,7 +207,7 @@ public sealed class Day03 : Puzzle
             new(-1, -1),
             new(-1, 0),
             new(-1, 1),
-        };
+        }.ToImmutableArray();
 
         /// <summary>
         /// Writes the value for the specified address to memory.

--- a/src/AdventOfCode/Puzzles/Y2017/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day04.cs
@@ -52,7 +52,7 @@ public sealed class Day04 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        ICollection<string> passphrases = await ReadResourceAsLinesAsync(cancellationToken);
+        var passphrases = await ReadResourceAsLinesAsync(cancellationToken);
 
         ValidPassphraseCountV1 = passphrases.Count((p) => IsPassphraseValid(p, 1));
         ValidPassphraseCountV2 = passphrases.Count((p) => IsPassphraseValid(p, 2));

--- a/src/AdventOfCode/Puzzles/Y2017/Day05.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day05.cs
@@ -57,7 +57,7 @@ public sealed class Day05 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<int> program = await ReadResourceAsNumbersAsync<int>(cancellationToken);
+        var program = await ReadResourceAsNumbersAsync<int>(cancellationToken);
 
         StepsToExitV1 = Execute(program, 1);
         StepsToExitV2 = Execute(program, 2);

--- a/src/AdventOfCode/Puzzles/Y2017/Day07.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day07.cs
@@ -52,7 +52,7 @@ public sealed class Day07 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> structure = await ReadResourceAsLinesAsync(cancellationToken);
+        var structure = await ReadResourceAsLinesAsync(cancellationToken);
 
         BottomProgramName = FindBottomProgramName(structure);
         DesiredWeightOfUnbalancedDisc = FindDesiredWeightOfUnbalancedDisc(structure);

--- a/src/AdventOfCode/Puzzles/Y2017/Day08.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day08.cs
@@ -48,7 +48,7 @@ public sealed class Day08 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> instructions = await ReadResourceAsLinesAsync(cancellationToken);
+        var instructions = await ReadResourceAsLinesAsync(cancellationToken);
 
         HighestRegisterValueAtEnd = FindHighestRegisterValueAtEnd(instructions);
         HighestRegisterValueDuring = FindHighestRegisterValueDuring(instructions);

--- a/src/AdventOfCode/Puzzles/Y2017/Day10.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day10.cs
@@ -17,7 +17,7 @@ public sealed class Day10 : Puzzle
     /// <summary>
     /// The suffix for all hash operations.
     /// </summary>
-    private static readonly int[] Suffix = { 17, 31, 73, 47, 23 };
+    private static readonly ImmutableArray<int> Suffix = new[] { 17, 31, 73, 47, 23 }.ToImmutableArray();
 
     /// <summary>
     /// Gets the product of multiplying the first two elements after the hash is applied to the input.

--- a/src/AdventOfCode/Puzzles/Y2017/Day12.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day12.cs
@@ -64,7 +64,7 @@ public sealed class Day12 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> pipes = await ReadResourceAsLinesAsync(cancellationToken);
+        var pipes = await ReadResourceAsLinesAsync(cancellationToken);
 
         ProgramsInGroupOfProgram0 = GetProgramsInGroup(0, pipes);
         NumberOfGroups = GetGroupsInNetwork(pipes);

--- a/src/AdventOfCode/Puzzles/Y2017/Day13.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day13.cs
@@ -102,7 +102,7 @@ public sealed class Day13 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> depthRanges = await ReadResourceAsLinesAsync(cancellationToken);
+        var depthRanges = await ReadResourceAsLinesAsync(cancellationToken);
 
         Severity = GetSeverityOfTrip(depthRanges);
         ShortestDelay = GetShortestDelayForNeverCaught(depthRanges);

--- a/src/AdventOfCode/Puzzles/Y2017/Day15.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day15.cs
@@ -106,7 +106,7 @@ public sealed class Day15 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> input = await ReadResourceAsLinesAsync(cancellationToken);
+        var input = await ReadResourceAsLinesAsync(cancellationToken);
 
         FinalCountV1 = GetMatchingPairs(input, version: 1);
         FinalCountV2 = GetMatchingPairs(input, version: 2);

--- a/src/AdventOfCode/Puzzles/Y2018/Day01.cs
+++ b/src/AdventOfCode/Puzzles/Y2018/Day01.cs
@@ -77,7 +77,7 @@ public sealed class Day01 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<int> sequence = await ReadResourceAsNumbersAsync<int>(cancellationToken);
+        var sequence = await ReadResourceAsNumbersAsync<int>(cancellationToken);
 
         (Frequency, FirstRepeatedFrequency) = CalculateFrequencyWithRepetition(sequence);
 

--- a/src/AdventOfCode/Puzzles/Y2018/Day02.cs
+++ b/src/AdventOfCode/Puzzles/Y2018/Day02.cs
@@ -132,7 +132,7 @@ public sealed class Day02 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> ids = await ReadResourceAsLinesAsync(cancellationToken);
+        var ids = await ReadResourceAsLinesAsync(cancellationToken);
 
         Checksum = CalculateChecksum(ids);
         CommonLettersForBoxes = GetCommonLetters(ids);

--- a/src/AdventOfCode/Puzzles/Y2018/Day03.cs
+++ b/src/AdventOfCode/Puzzles/Y2018/Day03.cs
@@ -91,7 +91,7 @@ public sealed class Day03 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> claims = await ReadResourceAsLinesAsync(cancellationToken);
+        var claims = await ReadResourceAsLinesAsync(cancellationToken);
 
         Area = GetAreaWithTwoOrMoreOverlappingClaims(claims);
         IdOfUniqueClaim = GetClaimWithNoOverlappingClaims(claims);

--- a/src/AdventOfCode/Puzzles/Y2018/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2018/Day04.cs
@@ -145,7 +145,7 @@ public sealed class Day04 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> log = await ReadResourceAsLinesAsync(cancellationToken);
+        var log = await ReadResourceAsLinesAsync(cancellationToken);
 
         (SleepiestGuardMinute, SleepiestMinuteGuard) = GetSleepiestGuardsMinutes(log);
 

--- a/src/AdventOfCode/Puzzles/Y2019/Day01.cs
+++ b/src/AdventOfCode/Puzzles/Y2019/Day01.cs
@@ -45,7 +45,7 @@ public sealed class Day01 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<int> masses = await ReadResourceAsNumbersAsync<int>(cancellationToken);
+        var masses = await ReadResourceAsNumbersAsync<int>(cancellationToken);
 
         TotalFuelRequiredForModules = masses.Sum((p) => GetFuelRequirementsForMass(p, includeFuel: false));
         TotalFuelRequiredForRocket = masses.Sum((p) => GetFuelRequirementsForMass(p, includeFuel: true));

--- a/src/AdventOfCode/Puzzles/Y2019/Day03.cs
+++ b/src/AdventOfCode/Puzzles/Y2019/Day03.cs
@@ -120,7 +120,7 @@ public sealed class Day03 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> wires = await ReadResourceAsLinesAsync(cancellationToken);
+        var wires = await ReadResourceAsLinesAsync(cancellationToken);
 
         (ManhattanDistance, MinimumSteps) = GetManhattanDistanceOfClosesIntersection(wires);
 

--- a/src/AdventOfCode/Puzzles/Y2020/Day01.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day01.cs
@@ -41,7 +41,7 @@ public sealed class Day01 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<int> values = await ReadResourceAsNumbersAsync<int>(cancellationToken);
+        var values = await ReadResourceAsNumbersAsync<int>(cancellationToken);
 
         ProductOf2020SumFrom2 = Get2020Product(values, 2);
         ProductOf2020SumFrom3 = Get2020Product(values, 3);

--- a/src/AdventOfCode/Puzzles/Y2020/Day02.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day02.cs
@@ -69,7 +69,7 @@ public sealed class Day02 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> values = await ReadResourceAsLinesAsync(cancellationToken);
+        var values = await ReadResourceAsLinesAsync(cancellationToken);
 
         ValidPasswordsV1 = GetValidPasswordCount(values, policyVersion: 1);
         ValidPasswordsV2 = GetValidPasswordCount(values, policyVersion: 2);

--- a/src/AdventOfCode/Puzzles/Y2020/Day03.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day03.cs
@@ -78,7 +78,7 @@ public sealed class Day03 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> grid = await ReadResourceAsLinesAsync(cancellationToken);
+        var grid = await ReadResourceAsLinesAsync(cancellationToken);
 
         var slopes = new[]
         {

--- a/src/AdventOfCode/Puzzles/Y2020/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day04.cs
@@ -84,7 +84,7 @@ public sealed partial class Day04 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> batch = await ReadResourceAsLinesAsync(cancellationToken);
+        var batch = await ReadResourceAsLinesAsync(cancellationToken);
 
         (ValidPassports, VerifiedPassports) = VerifyPassports(batch);
 

--- a/src/AdventOfCode/Puzzles/Y2020/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day04.cs
@@ -15,7 +15,7 @@ public sealed partial class Day04 : Puzzle
     /// <summary>
     /// The required keys for passports. This field is read-only.
     /// </summary>
-    private static readonly string[] RequiredKeys = { "byr", "ecl", "eyr", "hcl", "hgt", "iyr", "pid" };
+    private static readonly ImmutableArray<string> RequiredKeys = new[] { "byr", "ecl", "eyr", "hcl", "hgt", "iyr", "pid" }.ToImmutableArray();
 
     /// <summary>
     /// Gets the number of valid passports.

--- a/src/AdventOfCode/Puzzles/Y2020/Day05.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day05.cs
@@ -78,7 +78,7 @@ public sealed class Day05 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> boardingPasses = await ReadResourceAsLinesAsync(cancellationToken);
+        var boardingPasses = await ReadResourceAsLinesAsync(cancellationToken);
 
         (MySeatId, HighestSeatId) = Process(boardingPasses);
 

--- a/src/AdventOfCode/Puzzles/Y2020/Day06.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day06.cs
@@ -66,7 +66,7 @@ public sealed class Day06 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> values = await ReadResourceAsLinesAsync(cancellationToken);
+        var values = await ReadResourceAsLinesAsync(cancellationToken);
 
         SumOfQuestionsAnyoneYes = GetSumOfQuestionsWithYesAnswers(values, byEveryone: false);
         SumOfQuestionsEveryoneYes = GetSumOfQuestionsWithYesAnswers(values, byEveryone: true);

--- a/src/AdventOfCode/Puzzles/Y2020/Day07.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day07.cs
@@ -134,7 +134,7 @@ public sealed class Day07 : Puzzle
     {
         string color = args[0];
 
-        IList<string> rules = await ReadResourceAsLinesAsync(cancellationToken);
+        var rules = await ReadResourceAsLinesAsync(cancellationToken);
 
         BagColorsThatCanContainColor = GetBagColorsThatCouldContainColor(rules, color);
         BagsInsideBag = GetInsideBagCount(rules, color);

--- a/src/AdventOfCode/Puzzles/Y2020/Day08.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day08.cs
@@ -90,7 +90,7 @@ public sealed class Day08 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> program = await ReadResourceAsLinesAsync(cancellationToken);
+        var program = await ReadResourceAsLinesAsync(cancellationToken);
 
         Accumulator = RunProgram(program, fix: false);
         AccumulatorWithFix = RunProgram(program, fix: true);

--- a/src/AdventOfCode/Puzzles/Y2020/Day08.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day08.cs
@@ -182,7 +182,7 @@ public sealed class Day08 : Puzzle
     /// <summary>
     /// Represents a CPU instruction.
     /// </summary>
-    private record struct Instruction
+    private readonly record struct Instruction
     {
         /// <summary>
         /// Gets the operation to perform.

--- a/src/AdventOfCode/Puzzles/Y2020/Day10.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day10.cs
@@ -144,7 +144,7 @@ public sealed class Day10 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<int> joltages = await ReadResourceAsNumbersAsync<int>(cancellationToken);
+        var joltages = await ReadResourceAsNumbersAsync<int>(cancellationToken);
 
         JoltageProduct = GetJoltageProduct(joltages);
         ValidArrangements = GetValidArrangements(joltages);

--- a/src/AdventOfCode/Puzzles/Y2020/Day11.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day11.cs
@@ -66,7 +66,7 @@ public sealed class Day11 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> layout = await ReadResourceAsLinesAsync(cancellationToken);
+        var layout = await ReadResourceAsLinesAsync(cancellationToken);
 
         (int occupiedSeatsV1, string visualizationV1) = GetOccupiedSeats(layout, version: 1);
         (int occupiedSeatsV2, string visualizationV2) = GetOccupiedSeats(layout, version: 2);

--- a/src/AdventOfCode/Puzzles/Y2020/Day12.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day12.cs
@@ -153,7 +153,7 @@ public sealed class Day12 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> instructions = await ReadResourceAsLinesAsync(cancellationToken);
+        var instructions = await ReadResourceAsLinesAsync(cancellationToken);
 
         ManhattanDistance = GetDistanceTravelled(instructions);
         ManhattanDistanceWithWaypoint = GetDistanceTravelledWithWaypoint(instructions);

--- a/src/AdventOfCode/Puzzles/Y2020/Day13.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day13.cs
@@ -99,7 +99,7 @@ public sealed class Day13 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> notes = await ReadResourceAsLinesAsync(cancellationToken);
+        var notes = await ReadResourceAsLinesAsync(cancellationToken);
 
         BusWaitProduct = GetEarliestBusWaitProduct(notes);
         EarliestTimestamp = GetEarliestTimestamp(notes);

--- a/src/AdventOfCode/Puzzles/Y2020/Day13.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day13.cs
@@ -20,7 +20,7 @@ public sealed class Day13 : Puzzle
     public long EarliestTimestamp { get; private set; }
 
     /// <summary>
-    /// Gets the product of the earliest busand the number of minutes to wait for it.
+    /// Gets the product of the earliest bus and the number of minutes to wait for it.
     /// </summary>
     /// <param name="notes">The notes for the bus schedules.</param>
     /// <returns>

--- a/src/AdventOfCode/Puzzles/Y2020/Day14.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day14.cs
@@ -122,7 +122,7 @@ public sealed class Day14 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> values = await ReadResourceAsLinesAsync(cancellationToken);
+        var values = await ReadResourceAsLinesAsync(cancellationToken);
 
         SumOfRemainingValuesV1 = RunProgram(values, version: 1);
         SumOfRemainingValuesV2 = RunProgram(values, version: 2);

--- a/src/AdventOfCode/Puzzles/Y2020/Day16.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day16.cs
@@ -174,7 +174,7 @@ public sealed class Day16 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> values = await ReadResourceAsLinesAsync(cancellationToken);
+        var values = await ReadResourceAsLinesAsync(cancellationToken);
 
         (int scanningErrorRate, var ticket) = ScanTickets(values);
 

--- a/src/AdventOfCode/Puzzles/Y2020/Day17.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day17.cs
@@ -58,7 +58,7 @@ public sealed class Day17 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> layout = await ReadResourceAsLinesAsync(cancellationToken);
+        var layout = await ReadResourceAsLinesAsync(cancellationToken);
 
         int cycles = 6;
 

--- a/src/AdventOfCode/Puzzles/Y2020/Day18.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day18.cs
@@ -146,7 +146,7 @@ public sealed class Day18 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> expressions = await ReadResourceAsLinesAsync(cancellationToken);
+        var expressions = await ReadResourceAsLinesAsync(cancellationToken);
 
         SumV1 = Evaluate(expressions, version: 1);
         SumV2 = Evaluate(expressions, version: 2);

--- a/src/AdventOfCode/Puzzles/Y2020/Day19.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day19.cs
@@ -122,7 +122,7 @@ public sealed class Day19 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> input = await ReadResourceAsLinesAsync(cancellationToken);
+        var input = await ReadResourceAsLinesAsync(cancellationToken);
 
         MatchesRule0 = GetMatchCount(input, applyFix: false);
         MatchesRule0WithFix = GetMatchCount(input, applyFix: true);

--- a/src/AdventOfCode/Puzzles/Y2020/Day20.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day20.cs
@@ -452,7 +452,7 @@ public sealed class Day20 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> tiles = await ReadResourceAsLinesAsync(cancellationToken);
+        var tiles = await ReadResourceAsLinesAsync(cancellationToken);
 
         (long productOfCornerTiles, int waterRoughness, string image) = GetCornerTileIdProduct(tiles, Logger);
 

--- a/src/AdventOfCode/Puzzles/Y2020/Day21.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day21.cs
@@ -119,7 +119,7 @@ public sealed class Day21 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> recipies = await ReadResourceAsLinesAsync(cancellationToken);
+        var recipies = await ReadResourceAsLinesAsync(cancellationToken);
 
         (IngredientsWithNoAllergens, CanonicalAllergens) = GetIngredientsWithNoAllergens(recipies, cancellationToken);
 

--- a/src/AdventOfCode/Puzzles/Y2020/Day22.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day22.cs
@@ -122,7 +122,7 @@ public sealed class Day22 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> values = await ReadResourceAsLinesAsync(cancellationToken);
+        var values = await ReadResourceAsLinesAsync(cancellationToken);
 
         WinningScore = PlayCombat(values, recursive: false);
         WinningScoreRecursive = PlayCombat(values, recursive: true);

--- a/src/AdventOfCode/Puzzles/Y2020/Day24.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day24.cs
@@ -122,7 +122,7 @@ public sealed class Day24 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> instructions = await ReadResourceAsLinesAsync(cancellationToken);
+        var instructions = await ReadResourceAsLinesAsync(cancellationToken);
 
         BlackTilesDay0 = TileFloor(instructions, days: 0);
         BlackTilesDay100 = TileFloor(instructions, days: 100);

--- a/src/AdventOfCode/Puzzles/Y2020/Day25.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day25.cs
@@ -62,7 +62,7 @@ public sealed class Day25 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<int> values = await ReadResourceAsNumbersAsync<int>(cancellationToken);
+        var values = await ReadResourceAsNumbersAsync<int>(cancellationToken);
 
         PrivateKey = GetPrivateKey(values[0], values[1]);
 

--- a/src/AdventOfCode/Puzzles/Y2021/Day01.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day01.cs
@@ -63,7 +63,7 @@ public sealed class Day01 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<int> values = await ReadResourceAsNumbersAsync<int>(cancellationToken);
+        var values = await ReadResourceAsNumbersAsync<int>(cancellationToken);
 
         DepthIncreases = GetDepthMeasurementIncreases(values, useSlidingWindow: false);
         DepthIncreasesWithSlidingWindow = GetDepthMeasurementIncreases(values, useSlidingWindow: true);

--- a/src/AdventOfCode/Puzzles/Y2021/Day02.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day02.cs
@@ -76,7 +76,7 @@ public sealed class Day02 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> course = await ReadResourceAsLinesAsync(cancellationToken);
+        var course = await ReadResourceAsLinesAsync(cancellationToken);
 
         ProductOfFinalPosition = NavigateCourse(course, useAim: false);
         ProductOfFinalPositionWithAim = NavigateCourse(course, useAim: true);

--- a/src/AdventOfCode/Puzzles/Y2021/Day03.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day03.cs
@@ -99,7 +99,7 @@ public sealed class Day03 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> diagnosticReport = await ReadResourceAsLinesAsync(cancellationToken);
+        var diagnosticReport = await ReadResourceAsLinesAsync(cancellationToken);
 
         PowerConsumption = GetPowerConsumption(diagnosticReport);
         LifeSupportRating = GetLifeSupportRating(diagnosticReport);

--- a/src/AdventOfCode/Puzzles/Y2021/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day04.cs
@@ -62,7 +62,7 @@ public sealed class Day04 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> game = await ReadResourceAsLinesAsync(cancellationToken);
+        var game = await ReadResourceAsLinesAsync(cancellationToken);
 
         (FirstWinningScore, LastWinningScore) = PlayBingo(game);
 

--- a/src/AdventOfCode/Puzzles/Y2021/Day05.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day05.cs
@@ -64,7 +64,7 @@ public sealed class Day05 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> lineSegments = await ReadResourceAsLinesAsync(cancellationToken);
+        var lineSegments = await ReadResourceAsLinesAsync(cancellationToken);
 
         OverlappingVents = NavigateVents(lineSegments, useDiagonals: false);
         OverlappingVentsWithDiagonals = NavigateVents(lineSegments, useDiagonals: true);

--- a/src/AdventOfCode/Puzzles/Y2021/Day08.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day08.cs
@@ -127,7 +127,7 @@ public sealed class Day08 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> entries = await ReadResourceAsLinesAsync(cancellationToken);
+        var entries = await ReadResourceAsLinesAsync(cancellationToken);
 
         (Count, Sum) = DecodeDigits(entries);
 

--- a/src/AdventOfCode/Puzzles/Y2021/Day09.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day09.cs
@@ -114,7 +114,7 @@ public sealed class Day09 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> heightmap = await ReadResourceAsLinesAsync(cancellationToken);
+        var heightmap = await ReadResourceAsLinesAsync(cancellationToken);
 
         (SumOfRiskLevels, AreaOfThreeLargestBasins) = AnalyzeRisk(heightmap, cancellationToken);
 

--- a/src/AdventOfCode/Puzzles/Y2021/Day10.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day10.cs
@@ -127,7 +127,7 @@ public sealed class Day10 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> lines = await ReadResourceAsLinesAsync(cancellationToken);
+        var lines = await ReadResourceAsLinesAsync(cancellationToken);
 
         (SyntaxErrorScore, MiddleAutoCompleteScore) = Compile(lines);
 

--- a/src/AdventOfCode/Puzzles/Y2021/Day11.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day11.cs
@@ -149,7 +149,7 @@ public sealed class Day11 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> lines = await ReadResourceAsLinesAsync(cancellationToken);
+        var lines = await ReadResourceAsLinesAsync(cancellationToken);
 
         (Flashes100, _) = Simulate(lines, steps: 100);
         (_, StepOfFirstSynchronizedFlash) = Simulate(lines, steps: int.MaxValue);

--- a/src/AdventOfCode/Puzzles/Y2021/Day12.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day12.cs
@@ -46,7 +46,7 @@ public sealed class Day12 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> nodes = await ReadResourceAsLinesAsync(cancellationToken);
+        var nodes = await ReadResourceAsLinesAsync(cancellationToken);
 
         Count1 = Navigate(nodes, smallCaveVisitLimit: 1);
         Count2 = Navigate(nodes, smallCaveVisitLimit: 2);

--- a/src/AdventOfCode/Puzzles/Y2021/Day13.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day13.cs
@@ -135,7 +135,7 @@ public sealed class Day13 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> instructions = await ReadResourceAsLinesAsync(cancellationToken);
+        var instructions = await ReadResourceAsLinesAsync(cancellationToken);
 
         (DotCountAfterFold1, _, _) = Fold(instructions, folds: 1);
         (_, ActivationCode, string? visualization) = Fold(instructions, folds: null, Logger);

--- a/src/AdventOfCode/Puzzles/Y2021/Day14.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day14.cs
@@ -92,7 +92,7 @@ public sealed class Day14 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> instructions = await ReadResourceAsLinesAsync(cancellationToken);
+        var instructions = await ReadResourceAsLinesAsync(cancellationToken);
 
         Score10 = Expand(instructions, steps: 10);
         Score40 = Expand(instructions, steps: 40);

--- a/src/AdventOfCode/Puzzles/Y2021/Day15.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day15.cs
@@ -106,7 +106,7 @@ public sealed class Day15 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> riskMap = await ReadResourceAsLinesAsync(cancellationToken);
+        var riskMap = await ReadResourceAsLinesAsync(cancellationToken);
 
         RiskLevelSmall = GetRiskLevel(riskMap, largeMap: false, cancellationToken);
         RiskLevelLarge = GetRiskLevel(riskMap, largeMap: true, cancellationToken);

--- a/src/AdventOfCode/Puzzles/Y2021/Day18.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day18.cs
@@ -111,7 +111,7 @@ public sealed class Day18 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> numbers = await ReadResourceAsLinesAsync(cancellationToken);
+        var numbers = await ReadResourceAsLinesAsync(cancellationToken);
 
         (MagnitudeOfSum, LargestSumMagnitude) = Sum(numbers);
 

--- a/src/AdventOfCode/Puzzles/Y2021/Day19.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day19.cs
@@ -219,7 +219,7 @@ public sealed class Day19 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> target = await ReadResourceAsLinesAsync(cancellationToken);
+        var target = await ReadResourceAsLinesAsync(cancellationToken);
 
         (BeaconCount, LargestScannerDistance) = FindBeacons(target, cancellationToken);
 

--- a/src/AdventOfCode/Puzzles/Y2021/Day20.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day20.cs
@@ -145,7 +145,7 @@ public sealed class Day20 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> imageData = await ReadResourceAsLinesAsync(cancellationToken);
+        var imageData = await ReadResourceAsLinesAsync(cancellationToken);
 
         (LitPixelCount2, _) = Enhance(imageData, enhancements: 2);
         (LitPixelCount50, _) = Enhance(imageData, enhancements: 50);

--- a/src/AdventOfCode/Puzzles/Y2021/Day21.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day21.cs
@@ -170,7 +170,7 @@ public sealed class Day21 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> players = await ReadResourceAsLinesAsync(cancellationToken);
+        var players = await ReadResourceAsLinesAsync(cancellationToken);
 
         PracticeOutcome = PlayPractice(players);
         WinningUniverses = Play(players);

--- a/src/AdventOfCode/Puzzles/Y2021/Day22.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day22.cs
@@ -140,7 +140,7 @@ public sealed class Day22 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> instructions = await ReadResourceAsLinesAsync(cancellationToken);
+        var instructions = await ReadResourceAsLinesAsync(cancellationToken);
 
         InitializedCubeCount = Reboot(instructions, initialize: true);
         RebootedCubeCount = Reboot(instructions, initialize: false);

--- a/src/AdventOfCode/Puzzles/Y2021/Day23.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day23.cs
@@ -60,7 +60,7 @@ public sealed class Day23 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> diagram = await ReadResourceAsLinesAsync(cancellationToken);
+        var diagram = await ReadResourceAsLinesAsync(cancellationToken);
 
         MinimumEnergyFolded = Organize(diagram, unfoldDiagram: false, cancellationToken);
         MinimumEnergyUnfolded = Organize(diagram, unfoldDiagram: true, cancellationToken);

--- a/src/AdventOfCode/Puzzles/Y2021/Day23.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day23.cs
@@ -130,8 +130,8 @@ public sealed class Day23 : Puzzle
 
     private sealed class Burrow : IWeightedGraph<State>
     {
-        private static readonly char[] Amphipods = { 'D', 'C', 'B', 'A' };
-        private static readonly int[] HallwaySpaces = { 0, 1, 3, 5, 7, 9, 10 };
+        private static readonly ImmutableArray<char> Amphipods = new[] { 'D', 'C', 'B', 'A' }.ToImmutableArray();
+        private static readonly ImmutableArray<int> HallwaySpaces = new[] { 0, 1, 3, 5, 7, 9, 10 }.ToImmutableArray();
 
         public long Cost(State a, State b)
         {

--- a/src/AdventOfCode/Puzzles/Y2021/Day23.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day23.cs
@@ -85,7 +85,7 @@ public sealed class Day23 : Puzzle
             _ => throw new InvalidOperationException(),
         };
 
-        public string Burrow(char burrow) => burrow switch
+        public readonly string Burrow(char burrow) => burrow switch
         {
             'A' => Amber,
             'B' => Bronze,
@@ -94,16 +94,16 @@ public sealed class Day23 : Puzzle
             _ => throw new InvalidOperationException(),
         };
 
-        public bool HasSpace(char burrow) => Burrow(burrow).Contains(' ', StringComparison.Ordinal);
+        public readonly bool HasSpace(char burrow) => Burrow(burrow).Contains(' ', StringComparison.Ordinal);
 
-        public bool IsEmpty(char burrow) => string.IsNullOrWhiteSpace(Burrow(burrow));
+        public readonly bool IsEmpty(char burrow) => string.IsNullOrWhiteSpace(Burrow(burrow));
 
-        public bool IsOrganized(char burrow) => Burrow(burrow).TrimStart().All((p) => p == burrow);
+        public readonly bool IsOrganized(char burrow) => Burrow(burrow).TrimStart().All((p) => p == burrow);
 
-        public bool IsPathClear(char sourceBurrow, int destinationBurrow, bool fromHallway)
+        public readonly bool IsPathClear(char sourceBurrow, int destinationBurrow, bool fromHallway)
             => IsPathClear(Entrance(sourceBurrow), destinationBurrow, fromHallway);
 
-        public bool IsPathClear(int sourceBurrow, int destinationBurrow, bool fromHallway)
+        public readonly bool IsPathClear(int sourceBurrow, int destinationBurrow, bool fromHallway)
         {
             int startIndex = Math.Min(sourceBurrow, destinationBurrow);
             int endIndex = Math.Max(sourceBurrow, destinationBurrow);

--- a/src/AdventOfCode/Puzzles/Y2021/Day24.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day24.cs
@@ -80,7 +80,7 @@ public sealed class Day24 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> instructions = await ReadResourceAsLinesAsync(cancellationToken);
+        var instructions = await ReadResourceAsLinesAsync(cancellationToken);
 
         MaximumValidModelNumber = Execute(instructions, maximumValue: true);
         MinimumValidModelNumber = Execute(instructions, maximumValue: false);

--- a/src/AdventOfCode/Puzzles/Y2021/Day25.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day25.cs
@@ -124,7 +124,7 @@ public sealed class Day25 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<string> instructions = await ReadResourceAsLinesAsync(cancellationToken);
+        var instructions = await ReadResourceAsLinesAsync(cancellationToken);
 
         FirstStepWithNoMoves = ClearSeaFloor(instructions);
 

--- a/src/AdventOfCode/Puzzles/Y2022/Day17.cs
+++ b/src/AdventOfCode/Puzzles/Y2022/Day17.cs
@@ -93,11 +93,11 @@ public sealed class Day17 : Puzzle
 
     private sealed class Rock
     {
-        public static readonly IReadOnlyList<Point> Horizontal = new Point[] { new(0, 0), new(1, 0), new(2, 0), new(3, 0) };
-        public static readonly IReadOnlyList<Point> Plus = new Point[] { new(1, 0), new(0, 1), new(1, 1), new(2, 1), new(1, 2) };
-        public static readonly IReadOnlyList<Point> Boomerang = new Point[] { new(0, 0), new(1, 0), new(2, 0), new(2, 1), new(2, 2) };
-        public static readonly IReadOnlyList<Point> Vertical = new Point[] { new(0, 0), new(0, 1), new(0, 2), new(0, 3) };
-        public static readonly IReadOnlyList<Point> Square = new Point[] { new(0, 0), new(1, 0), new(0, 1), new(1, 1) };
+        public static readonly ImmutableArray<Point> Horizontal = new Point[] { new(0, 0), new(1, 0), new(2, 0), new(3, 0) }.ToImmutableArray();
+        public static readonly ImmutableArray<Point> Plus = new Point[] { new(1, 0), new(0, 1), new(1, 1), new(2, 1), new(1, 2) }.ToImmutableArray();
+        public static readonly ImmutableArray<Point> Boomerang = new Point[] { new(0, 0), new(1, 0), new(2, 0), new(2, 1), new(2, 2) }.ToImmutableArray();
+        public static readonly ImmutableArray<Point> Vertical = new Point[] { new(0, 0), new(0, 1), new(0, 2), new(0, 3) }.ToImmutableArray();
+        public static readonly ImmutableArray<Point> Square = new Point[] { new(0, 0), new(1, 0), new(0, 1), new(1, 1) }.ToImmutableArray();
 
         private Rock(IReadOnlyList<Point> points)
         {

--- a/src/AdventOfCode/SquareGrid.cs
+++ b/src/AdventOfCode/SquareGrid.cs
@@ -77,9 +77,9 @@ public abstract class SquareGrid : IWeightedGraph<Point>
     /// <inheritdoc/>
     public virtual IEnumerable<Point> Neighbors(Point id)
     {
-        foreach (Size vector in Vectors)
+        for (int i = 0; i < Vectors.Length; i++)
         {
-            Point next = id + vector;
+            Point next = id + Vectors[i];
 
             if (InBounds(next) && IsPassable(next))
             {

--- a/src/AdventOfCode/SquareGrid.cs
+++ b/src/AdventOfCode/SquareGrid.cs
@@ -14,13 +14,13 @@ public abstract class SquareGrid : IWeightedGraph<Point>
     /// <summary>
     /// The valid vectors of movement around the grid.
     /// </summary>
-    private static readonly Size[] Vectors =
+    private static readonly ImmutableArray<Size> Vectors = new Size[]
     {
         new(0, 1),
         new(1, 0),
         new(0, -1),
         new(-1, 0),
-    };
+    }.ToImmutableArray();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SquareGrid"/> class.

--- a/tests/AdventOfCode.Tests/Puzzles/Y2015/Day05Tests.cs
+++ b/tests/AdventOfCode.Tests/Puzzles/Y2015/Day05Tests.cs
@@ -60,7 +60,7 @@ public sealed class Day05Tests : PuzzleTest
     public static void Y2015_Day05_HasPairOfLettersWithMoreThanOneOccurence(string value, bool expected)
     {
         // Act
-        bool actual = Day05.HasPairOfLettersWithMoreThanOneOccurence(value);
+        bool actual = Day05.HasPairOfLettersWithMoreThanOneOccurrence(value);
 
         // Assert
         actual.ShouldBe(expected);


### PR DESCRIPTION
Cherry-pick performance improvements from #992:

- Use `List<T>` instead of `IList<T>` to devirtualize lists
- Refactor to use `ImmutableArray<T>` where relevant
- Remove locals that can be elided
- Make struct and members `readonly` where relevant
- Use `for` loop instead of `foreach` to remove iterator
- Fix typos
