### PR TITLE
Fix code analysis warning

### DIFF
--- a/src/AdventOfCode/Puzzles/Y2015/Day18.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day18.cs
@@ -112,7 +112,7 @@ public sealed class Day18 : Puzzle
 
         bool[,] output = new bool[width, height];
 
-        IList<Point> cornerLights;
+        Point[] cornerLights;
 
         if (areCornerLightsBroken)
         {


### PR DESCRIPTION
Use an array instead of an interface to avoid virtual calls identified in #1094.
