### PR TITLE
Fix test warnings

### DIFF
--- a/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
+++ b/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
@@ -5,6 +5,7 @@ using MartinCostello.Logging.XUnit;
 using MartinCostello.Testing.AwsLambdaTestServer;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -41,6 +42,7 @@ internal sealed class HttpLambdaTestServer : LambdaTestServer, IAsyncLifetime, I
         _webHost = builder
             .UseKestrel()
             .ConfigureServices((services) => services.AddLogging((builder) => builder.AddXUnit(this)))
+            .UseSolutionRelativeContentRoot(Path.Combine("src", "AdventOfCode.Site"))
             .UseUrls("http://127.0.0.1:0")
             .Build();
 

--- a/tests/AdventOfCode.Tests/Api/HttpServerFixture.cs
+++ b/tests/AdventOfCode.Tests/Api/HttpServerFixture.cs
@@ -73,8 +73,7 @@ public sealed class HttpServerFixture : WebApplicationFactory<Site.Program>, ITe
     /// <inheritdoc />
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
-        builder.ConfigureLogging((loggingBuilder) => loggingBuilder.ClearProviders().AddXUnit(this))
-               .UseSolutionRelativeContentRoot(Path.Combine("src", "AdventOfCode"));
+        builder.ConfigureLogging((loggingBuilder) => loggingBuilder.ClearProviders().AddXUnit(this));
 
         builder.ConfigureKestrel(
             (p) => p.ConfigureHttpsDefaults(

--- a/tests/AdventOfCode.Tests/Api/LambdaTests.cs
+++ b/tests/AdventOfCode.Tests/Api/LambdaTests.cs
@@ -16,6 +16,8 @@ namespace MartinCostello.AdventOfCode.Api;
 [Collection(nameof(LambdaTestsCollection))]
 public class LambdaTests : IAsyncLifetime, IDisposable
 {
+    private const int LambdaTestTimeout = 10_000;
+
     private readonly HttpLambdaTestServer _server;
     private bool _disposed;
 
@@ -45,7 +47,7 @@ public class LambdaTests : IAsyncLifetime, IDisposable
     public async Task InitializeAsync()
         => await _server.InitializeAsync();
 
-    [Fact(Timeout = 5_000)]
+    [Fact(Timeout = LambdaTestTimeout)]
     public async Task Can_Get_Puzzle_Metadata()
     {
         // Arrange
@@ -78,7 +80,7 @@ public class LambdaTests : IAsyncLifetime, IDisposable
         }
     }
 
-    [Theory(Timeout = 5_000)]
+    [Theory(Timeout = LambdaTestTimeout)]
     [InlineData(2015, 11, new[] { "cqjxjnds" }, new[] { "cqjxxyzz", "cqkaabcc" })]
     public async Task Can_Solve_Puzzle_With_Input_Arguments(int year, int day, string[] arguments, string[] expected)
     {
@@ -123,7 +125,7 @@ public class LambdaTests : IAsyncLifetime, IDisposable
         solutions.EnumerateArray().ToArray().Select((p) => p.GetString()).ToArray().ShouldBe(expected);
     }
 
-    [Theory(Timeout = 5_000)]
+    [Theory(Timeout = LambdaTestTimeout)]
     [InlineData(2015, 1, new[] { 232, 1783 })]
     public async Task Can_Solve_Puzzle_With_Input_File(int year, int day, int[] expected)
     {

--- a/tests/AdventOfCode.Tests/xunit.runner.json
+++ b/tests/AdventOfCode.Tests/xunit.runner.json
@@ -1,3 +1,4 @@
 {
-  "methodDisplay": "method"
+  "methodDisplay": "method",
+  "parallelizeTestCollections": false
 }


### PR DESCRIPTION
- Fix incorrect/redundant content root configuration for integration tests.
- Disable parallelism to stop the HTTP server integration tests running in parallel with each other.
