### PR TITLE
Build before run

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -42,10 +42,11 @@ jobs:
       env:
         SKIP_NPM_TEST: true
       run: |
+        dotnet build ./src/AdventOfCode.Site/AdventOfCode.Site.csproj --configuration Release
         Start-Process nohup 'dotnet run --project ./src/AdventOfCode.Site/AdventOfCode.Site.csproj --configuration Release'
         $StatusCode = 0
         $Attempts = 0
-        While ($Attempts -lt 20) {
+        While ($Attempts -lt 25) {
           $Response = Try {
             Invoke-WebRequest "https://localhost:5001" -SkipCertificateCheck
           } catch {


### PR DESCRIPTION
- Build the site before running it so npm doesn't contribute to the wait timer for the site to start.
- Increase the number of attempts to wait for the site to start.
