### PR TITLE
Reuse JsonSerializerOptions instance

### DIFF
--- a/src/AdventOfCode/Puzzles/Y2017/Day11.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day11.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using System.Numerics;
-
 namespace MartinCostello.AdventOfCode.Puzzles.Y2017;
 
 /// <summary>

--- a/src/AdventOfCode/Puzzles/Y2021/Day22.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day22.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using System.Numerics;
-
 namespace MartinCostello.AdventOfCode.Puzzles.Y2021;
 
 /// <summary>

--- a/tests/AdventOfCode.Tests/Api/LambdaTests.cs
+++ b/tests/AdventOfCode.Tests/Api/LambdaTests.cs
@@ -18,6 +18,8 @@ public class LambdaTests : IAsyncLifetime, IDisposable
 {
     private const int LambdaTestTimeout = 10_000;
 
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+
     private readonly HttpLambdaTestServer _server;
     private bool _disposed;
 
@@ -246,8 +248,7 @@ public class LambdaTests : IAsyncLifetime, IDisposable
         APIGatewayProxyRequest request)
     {
         // Arrange
-        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
-        string json = JsonSerializer.Serialize(request, options);
+        string json = JsonSerializer.Serialize(request, SerializerOptions);
 
         LambdaTestContext context = await _server.EnqueueAsync(json);
 
@@ -279,7 +280,7 @@ public class LambdaTests : IAsyncLifetime, IDisposable
         response.Content.ShouldNotBeEmpty();
 
         // Assert
-        var actual = JsonSerializer.Deserialize<APIGatewayProxyResponse>(response.Content, options);
+        var actual = JsonSerializer.Deserialize<APIGatewayProxyResponse>(response.Content, SerializerOptions);
 
         actual.ShouldNotBeNull();
 


### PR DESCRIPTION
- Reuse `JsonSerializerOptions` instance to resolve `CA1869` warning with .NET 8 RC1.
- Remove redundant `using` statements.
