### PR TITLE
Split out dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,9 +20,11 @@ updates:
 - package-ecosystem: npm
   directory: "/src/AdventOfCode.Site"
   groups:
-    dependencies:
+    babel:
       patterns:
         - "@babel/*"
+    typescript-eslint:
+      patterns:
         - "@typescript-eslint/*"
   schedule:
     interval: daily


### PR DESCRIPTION
Have a group each for babel and typescript-eslint, rather than combining them.
