### PR TITLE
Remove EnablePreviewFeatures

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,6 @@
     <Deterministic>true</Deterministic>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <EnablePreviewFeatures>true</EnablePreviewFeatures>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Remove `EnablePreviewFeatures` as it hasn't been needed since .NET 7 when generic math came out of preview.
