### PR TITLE
Use binary number formatting

### DIFF
--- a/src/AdventOfCode.Site/Program.cs
+++ b/src/AdventOfCode.Site/Program.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA1852
-
 using System.IO.Compression;
 using System.Reflection;
 using System.Runtime.InteropServices;

--- a/src/AdventOfCode/Puzzles/Y2016/Day13.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day13.cs
@@ -126,7 +126,7 @@ public sealed class Day13 : Puzzle
 
             z += seed;
 
-            string binary = Convert.ToString(z, toBase: 2);
+            string binary = z.ToString("b", CultureInfo.InvariantCulture);
 
             return binary.Count('1') % 2 != 0;
         }

--- a/tests/AdventOfCode.Benchmarks/Program.cs
+++ b/tests/AdventOfCode.Benchmarks/Program.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA1852
-
 using BenchmarkDotNet.Running;
 using MartinCostello.AdventOfCode.Benchmarks;
 


### PR DESCRIPTION
- Use `b` with `ToString()` instead of `Convert.ToString()` with a base.
- Remove redundant suppressions.

Inspired by [_Performance Improvements in .NET 8_](https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-8/#numbers).