### PR TITLE
Use MemoryExtensions.Count()

### DIFF
--- a/AdventOfCode.sln
+++ b/AdventOfCode.sln
@@ -15,7 +15,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		benchmark.yml = benchmark.yml
 		build.ps1 = build.ps1
 		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
-		CommonAssemblyInfo.cs = CommonAssemblyInfo.cs
 		crank.ps1 = crank.ps1
 		crank.yml = crank.yml
 		Directory.Build.props = Directory.Build.props

--- a/src/AdventOfCode/Puzzles/Y2015/Day18.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day18.cs
@@ -79,7 +79,7 @@ public sealed class Day18 : Puzzle
         string[] finalStuck = GetGridConfigurationAfterSteps(initial, steps, areCornerLightsBroken: true);
 
         LightsIlluminated = finalUnstuck.Sum((p) => p.Count(On));
-        LightsIlluminatedWithStuckLights = finalStuck.Sum((p) => p.Count(On));
+        LightsIlluminatedWithStuckLights = finalStuck.Sum((p) => System.MemoryExtensions.Count(p.AsSpan(), On));
 
         if (Verbose)
         {

--- a/src/AdventOfCode/Puzzles/Y2016/Day13.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day13.cs
@@ -128,7 +128,7 @@ public sealed class Day13 : Puzzle
 
             string binary = z.ToString("b", CultureInfo.InvariantCulture);
 
-            return binary.Count('1') % 2 != 0;
+            return System.MemoryExtensions.Count(binary.AsSpan(), '1') % 2 != 0;
         }
     }
 

--- a/src/AdventOfCode/Puzzles/Y2017/Day11.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day11.cs
@@ -147,9 +147,9 @@ public sealed class Day11 : Puzzle
     /// <returns>
     /// An array of <see cref="CardinalDirection"/> containing the parsed directions from the path.
     /// </returns>
-    private static CardinalDirection[] ParsePath(string path)
+    private static CardinalDirection[] ParsePath(ReadOnlySpan<char> path)
     {
-        var result = new CardinalDirection[path.Count(',') + 1];
+        var result = new CardinalDirection[System.MemoryExtensions.Count(path, ',') + 1];
 
         int i = 0;
 

--- a/src/AdventOfCode/Puzzles/Y2019/IntcodeVM.cs
+++ b/src/AdventOfCode/Puzzles/Y2019/IntcodeVM.cs
@@ -65,9 +65,9 @@ internal sealed class IntcodeVM
     /// <returns>
     /// The instructions of the program to run.
     /// </returns>
-    internal static long[] ParseProgram(string program)
+    internal static long[] ParseProgram(ReadOnlySpan<char> program)
     {
-        long[] instructions = new long[program.Count(',') + 1];
+        long[] instructions = new long[System.MemoryExtensions.Count(program, ',') + 1];
 
         int i = 0;
 

--- a/src/AdventOfCode/Puzzles/Y2020/Day02.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day02.cs
@@ -39,7 +39,7 @@ public sealed class Day02 : Puzzle
             int minimumCount = firstNumber;
             int maximumCount = secondNumber;
 
-            int count = password.Count(requiredCharacter);
+            int count = System.MemoryExtensions.Count(password.AsSpan(), requiredCharacter);
             return count >= minimumCount && count <= maximumCount;
         }
         else

--- a/src/AdventOfCode/Puzzles/Y2020/Day14.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day14.cs
@@ -35,7 +35,7 @@ public sealed class Day14 : Puzzle
         StringSplitOptions splitOptions = StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries;
 
         int floatingBits = 0;
-        string mask = string.Empty;
+        ReadOnlySpan<char> mask = string.Empty;
 
         var memory = new Dictionary<long, long>(program.Count);
 
@@ -46,7 +46,7 @@ public sealed class Day14 : Puzzle
                 // Flip the mask to match the endianness of BitArray
                 string maskValue = instruction[MaskPrefix.Length..];
                 mask = maskValue.Mirror();
-                floatingBits = mask.Count('X');
+                floatingBits = System.MemoryExtensions.Count(mask, 'X');
             }
             else
             {

--- a/src/AdventOfCode/Puzzles/Y2021/Day23.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day23.cs
@@ -187,11 +187,11 @@ public sealed class Day23 : Puzzle
                 }
             }
 
-            string before = a.Burrow(burrowChanged);
-            string after = b.Burrow(burrowChanged);
+            ReadOnlySpan<char> before = a.Burrow(burrowChanged);
+            ReadOnlySpan<char> after = b.Burrow(burrowChanged);
 
             int steps = Math.Abs(State.Entrance(burrowChanged) - index);
-            steps += Math.Max(before.Count(' '), after.Count(' '));
+            steps += Math.Max(System.MemoryExtensions.Count(before, ' '), System.MemoryExtensions.Count(after, ' '));
 
             int multiplier = (int)Math.Pow(10, amphipod - 'A');
 


### PR DESCRIPTION
- Use `System.MemoryExtensions.Count()` instead of the High Performance Toolkit version.
- Use `ReadOnlySpan<char>` in a few places instead of `string`.
- Remove deleted file from solution.
