### PR TITLE
Bump Amazon.Lambda.RuntimeSupport

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.6.0" />
+    <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.9.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.9" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />

--- a/src/AdventOfCode.Site/AdventOfCode.Site.csproj
+++ b/src/AdventOfCode.Site/AdventOfCode.Site.csproj
@@ -18,6 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" />
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" PrivateAssets="all" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>


### PR DESCRIPTION
Add an explicit reference to the Amazon.Lambda.RuntimeSupport NuGet package to use the most up-to-date version.
