### PR TITLE
Update amazon.lambda.runtimesupport redux

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.6.0" />
+    <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.9.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.9" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />

--- a/src/AdventOfCode.Site/AdventOfCode.Site.csproj
+++ b/src/AdventOfCode.Site/AdventOfCode.Site.csproj
@@ -18,6 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" />
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" PrivateAssets="all" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>

--- a/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
+++ b/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
@@ -5,7 +5,6 @@ using MartinCostello.Logging.XUnit;
 using MartinCostello.Testing.AwsLambdaTestServer;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
-using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -42,7 +41,6 @@ internal sealed class HttpLambdaTestServer : LambdaTestServer, IAsyncLifetime, I
         _webHost = builder
             .UseKestrel()
             .ConfigureServices((services) => services.AddLogging((builder) => builder.AddXUnit(this)))
-            .UseSolutionRelativeContentRoot(Path.Combine("src", "AdventOfCode.Site"))
             .UseUrls("http://127.0.0.1:0")
             .Build();
 

--- a/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
+++ b/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
@@ -17,7 +17,7 @@ internal sealed class HttpLambdaTestServer : LambdaTestServer, IAsyncLifetime, I
     private IWebHost? _webHost;
 
     public HttpLambdaTestServer()
-        : base()
+        : base(new LambdaTestServerOptions() { FunctionMemorySize = 384 })
     {
     }
 

--- a/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
+++ b/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
@@ -17,7 +17,7 @@ internal sealed class HttpLambdaTestServer : LambdaTestServer, IAsyncLifetime, I
     private IWebHost? _webHost;
 
     public HttpLambdaTestServer()
-        : base(new LambdaTestServerOptions() { FunctionMemorySize = 512 })
+        : base(new LambdaTestServerOptions() { FunctionMemorySize = 1024 })
     {
     }
 

--- a/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
+++ b/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
@@ -17,7 +17,7 @@ internal sealed class HttpLambdaTestServer : LambdaTestServer, IAsyncLifetime, I
     private IWebHost? _webHost;
 
     public HttpLambdaTestServer()
-        : base(new LambdaTestServerOptions() { FunctionMemorySize = 384 })
+        : base(new LambdaTestServerOptions() { FunctionMemorySize = 512 })
     {
     }
 

--- a/tests/AdventOfCode.Tests/Api/HttpServerFixture.cs
+++ b/tests/AdventOfCode.Tests/Api/HttpServerFixture.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -79,8 +78,7 @@ public sealed class HttpServerFixture : WebApplicationFactory<Site.Program>, ITe
             (p) => p.ConfigureHttpsDefaults(
                 (r) => r.ServerCertificate = new X509Certificate2("localhost-dev.pfx", "Pa55w0rd!")));
 
-        builder.UseEnvironment(Environments.Production)
-               .UseSolutionRelativeContentRoot(Path.Combine("src", "AdventOfCode.Site"));
+        builder.UseEnvironment(Environments.Production);
 
         // Configure the server address for the server to
         // listen on for HTTPS requests on a dynamic port.


### PR DESCRIPTION
- Add an explicit reference to the Amazon.Lambda.RuntimeSupport NuGet package to use the most up-to-date version.
- Increase Lambda Test Server's memory size to ~~match the function in production~~ 1024 to stop the NuGet package from reducing the heap size and causing `OutOfMemoryException` being thrown in the Lambda integration tests (see https://github.com/aws/aws-lambda-dotnet/issues/1594).
- Remove redundant calls to `UseSolutionRelativeContentRoot()` which might also fix warnings being logged about `WebRootPath` not being found.
