### PR TITLE
Revert Amazon.Lambda.RuntimeSupport bump

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,10 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.6.0" />
+    <!--
+    HACK See https://github.com/aws/aws-lambda-dotnet/issues/1594
     <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.9.0" />
+    -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.9" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />

--- a/src/AdventOfCode.Site/AdventOfCode.Site.csproj
+++ b/src/AdventOfCode.Site/AdventOfCode.Site.csproj
@@ -18,7 +18,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" />
+    <!--
+    HACK See https://github.com/aws/aws-lambda-dotnet/issues/1594
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" />
+    -->
     <PackageReference Include="Microsoft.TypeScript.MSBuild" PrivateAssets="all" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>

--- a/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
+++ b/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
@@ -16,11 +16,6 @@ internal sealed class HttpLambdaTestServer : LambdaTestServer, IAsyncLifetime, I
     private bool _disposed;
     private IWebHost? _webHost;
 
-    public HttpLambdaTestServer()
-        : base(new LambdaTestServerOptions() { FunctionMemorySize = 1024 })
-    {
-    }
-
     public ITestOutputHelper? OutputHelper { get; set; }
 
     public async Task DisposeAsync()


### PR DESCRIPTION
Revert update to Amazon.Lambda.RuntimeSupport from #1279 as it's still randomly causing `OutOfMemoryException` in CI ([example](https://github.com/martincostello/adventofcode/actions/runs/6532867949/job/17736875494#step:10:487)).
