### PR TITLE
Collection expressions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,6 +40,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>
     <SignAssembly>true</SignAssembly>
+    <StrongNamePublicKey Condition=" '$(SignAssembly)' == 'true'">00240000048000009400000006020000002400005253413100040000010001004b0b2efbada897147aa03d2076278890aefe2f8023562336d206ec8a719b06e89461c31b43abec615918d509158629f93385930c030494509e418bf396d69ce7dbe0b5b2db1a81543ab42777cb98210677fed69dbeb3237492a7ad69e87a1911ed20eb2d7c300238dc6f6403e3d04a1351c5cb369de4e022b18fbec70f7d21ed</StrongNamePublicKey>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <VersionPrefix>8.0.0</VersionPrefix>

--- a/src/AdventOfCode/AdventOfCode.csproj
+++ b/src/AdventOfCode/AdventOfCode.csproj
@@ -13,4 +13,8 @@
   <ItemGroup>
     <ProjectReference Include="..\AdventOfCode.Resources\AdventOfCode.Resources.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="AdventOfCode.Benchmarks" Key="$(StrongNamePublicKey)" />
+    <InternalsVisibleTo Include="AdventOfCode.Tests" Key="$(StrongNamePublicKey)" />
+  </ItemGroup>
 </Project>

--- a/src/AdventOfCode/Maths.cs
+++ b/src/AdventOfCode/Maths.cs
@@ -22,7 +22,7 @@ internal static class Maths
     {
         if (value == 0)
         {
-            return new[] { 0 };
+            return [0];
         }
 
         value = Math.Abs(value);

--- a/src/AdventOfCode/Properties/AssemblyInfo.cs
+++ b/src/AdventOfCode/Properties/AssemblyInfo.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: Guid("73a5961b-1a23-4d45-9baf-b5ac2070963e")]
-
-[assembly: InternalsVisibleTo("AdventOfCode.Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001004b0b2efbada897147aa03d2076278890aefe2f8023562336d206ec8a719b06e89461c31b43abec615918d509158629f93385930c030494509e418bf396d69ce7dbe0b5b2db1a81543ab42777cb98210677fed69dbeb3237492a7ad69e87a1911ed20eb2d7c300238dc6f6403e3d04a1351c5cb369de4e022b18fbec70f7d21ed")]
-[assembly: InternalsVisibleTo("AdventOfCode.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001004b0b2efbada897147aa03d2076278890aefe2f8023562336d206ec8a719b06e89461c31b43abec615918d509158629f93385930c030494509e418bf396d69ce7dbe0b5b2db1a81543ab42777cb98210677fed69dbeb3237492a7ad69e87a1911ed20eb2d7c300238dc6f6403e3d04a1351c5cb369de4e022b18fbec70f7d21ed")]

--- a/src/AdventOfCode/Puzzles/Y2015/Day09.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day09.cs
@@ -109,7 +109,7 @@ public sealed class Day09 : Puzzle
 
                 visited.Remove(location);
 
-                return new[] { distance };
+                return [distance];
             }
 
             var distances = new List<int>();

--- a/src/AdventOfCode/Puzzles/Y2015/Day21.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day21.cs
@@ -102,7 +102,7 @@ public sealed class Day21 : Puzzle
 
         foreach (string ring in keys)
         {
-            potentialRings.Add(new[] { ring });
+            potentialRings.Add([ring]);
         }
 
         var permutations = Maths.GetPermutations(keys, 2);

--- a/src/AdventOfCode/Puzzles/Y2019/Day05.cs
+++ b/src/AdventOfCode/Puzzles/Y2019/Day05.cs
@@ -37,7 +37,7 @@ public sealed class Day05 : Puzzle
 
         var vm = new IntcodeVM(instructions)
         {
-            Input = await ChannelHelpers.CreateReaderAsync(new[] { input }, cancellationToken),
+            Input = await ChannelHelpers.CreateReaderAsync([input], cancellationToken),
         };
 
         if (!await vm.RunAsync(cancellationToken))

--- a/tests/AdventOfCode.Tests/Api/LambdaTests.cs
+++ b/tests/AdventOfCode.Tests/Api/LambdaTests.cs
@@ -66,7 +66,7 @@ public class LambdaTests : IAsyncLifetime, IDisposable
         actual.ShouldNotBeNull();
         actual.StatusCode.ShouldBe(StatusCodes.Status200OK);
         actual.MultiValueHeaders.ShouldContainKey("Content-Type");
-        actual.MultiValueHeaders["Content-Type"].ShouldBe(new[] { "application/json; charset=utf-8" });
+        actual.MultiValueHeaders["Content-Type"].ShouldBe(["application/json; charset=utf-8"]);
 
         using var puzzles = JsonDocument.Parse(actual.Body);
 
@@ -114,7 +114,7 @@ public class LambdaTests : IAsyncLifetime, IDisposable
         actual.ShouldNotBeNull();
         actual.StatusCode.ShouldBe(StatusCodes.Status200OK);
         actual.MultiValueHeaders.ShouldContainKey("Content-Type");
-        actual.MultiValueHeaders["Content-Type"].ShouldBe(new[] { "application/json; charset=utf-8" });
+        actual.MultiValueHeaders["Content-Type"].ShouldBe(["application/json; charset=utf-8"]);
 
         using var solution = JsonDocument.Parse(actual.Body);
 
@@ -154,7 +154,7 @@ public class LambdaTests : IAsyncLifetime, IDisposable
         actual.ShouldNotBeNull();
         actual.StatusCode.ShouldBe(StatusCodes.Status200OK);
         actual.MultiValueHeaders.ShouldContainKey("Content-Type");
-        actual.MultiValueHeaders["Content-Type"].ShouldBe(new[] { "application/json; charset=utf-8" });
+        actual.MultiValueHeaders["Content-Type"].ShouldBe(["application/json; charset=utf-8"]);
 
         using var solution = JsonDocument.Parse(actual.Body);
 

--- a/tests/AdventOfCode.Tests/Api/UITests.cs
+++ b/tests/AdventOfCode.Tests/Api/UITests.cs
@@ -122,7 +122,7 @@ public class UITests : IntegrationTest, IClassFixture<PlaywrightFixture>
             await solver.SolveAsync();
 
             // Assert
-            await solver.SolutionsAsync().ShouldBe(new[] { "121", "RURUCEOEIL" });
+            await solver.SolutionsAsync().ShouldBe(["121", "RURUCEOEIL"]);
             await solver.VisualizationsAsync().ShouldBe(1);
         });
     }

--- a/tests/AdventOfCode.Tests/PlaywrightFixture.cs
+++ b/tests/AdventOfCode.Tests/PlaywrightFixture.cs
@@ -15,7 +15,7 @@ public class PlaywrightFixture : IAsyncLifetime
 
     private static void InstallPlaywright()
     {
-        int exitCode = Microsoft.Playwright.Program.Main(new[] { "install" });
+        int exitCode = Microsoft.Playwright.Program.Main(["install"]);
 
         if (exitCode != 0)
         {

--- a/tests/AdventOfCode.Tests/Puzzles/Y2015/Day19Tests.cs
+++ b/tests/AdventOfCode.Tests/Puzzles/Y2015/Day19Tests.cs
@@ -17,7 +17,7 @@ public sealed class Day19Tests(ITestOutputHelper outputHelper) : PuzzleTest(outp
 
         // Assert
         actual.ShouldNotBeNull();
-        actual.ShouldBe(new[] { "HHHH", "HOHO", "HOOH", "OHOH" });
+        actual.ShouldBe(["HHHH", "HOHO", "HOOH", "OHOH"]);
     }
 
     [Fact]

--- a/tests/AdventOfCode.Tests/Puzzles/Y2015/Day22Tests.cs
+++ b/tests/AdventOfCode.Tests/Puzzles/Y2015/Day22Tests.cs
@@ -21,7 +21,7 @@ public sealed class Day22Tests(ITestOutputHelper outputHelper) : PuzzleTest(outp
     public void Y2015_Day22_Fight_Win_Scenario_1()
     {
         // Arrange
-        IList<string> spellsToConjure = new[] { "Poison", "MagicMissile" };
+        IList<string> spellsToConjure = ["Poison", "MagicMissile"];
         int index = 0;
 
         string SpellSelector(Day22.Wizard w, ICollection<string> s) => spellsToConjure[index++];
@@ -43,7 +43,7 @@ public sealed class Day22Tests(ITestOutputHelper outputHelper) : PuzzleTest(outp
         wizard.Damage.ShouldBe(0);
         wizard.HitPoints.ShouldBe(2);
         wizard.Mana.ShouldBe(24);
-        wizard.ActiveSpells.ShouldBe(new[] { "Poison" });
+        wizard.ActiveSpells.ShouldBe(["Poison"]);
         wizard.ManaSpent.ShouldBe(173 + 53);
         wizard.SpellsCast.ShouldBe(spellsToConjure);
     }
@@ -52,7 +52,7 @@ public sealed class Day22Tests(ITestOutputHelper outputHelper) : PuzzleTest(outp
     public void Y2015_Day22_Fight_Win_Scenario_2()
     {
         // Arrange
-        IList<string> spellsToConjure = new[] { "Recharge", "Shield", "Drain", "Poison", "MagicMissile" };
+        IList<string> spellsToConjure = ["Recharge", "Shield", "Drain", "Poison", "MagicMissile"];
         int index = 0;
 
         string SpellSelector(Day22.Wizard w, ICollection<string> s) => spellsToConjure[index++];
@@ -73,7 +73,7 @@ public sealed class Day22Tests(ITestOutputHelper outputHelper) : PuzzleTest(outp
         wizard.Damage.ShouldBe(0);
         wizard.HitPoints.ShouldBe(1);
         wizard.Mana.ShouldBe(114);
-        wizard.ActiveSpells.ShouldBe(new[] { "Poison" });
+        wizard.ActiveSpells.ShouldBe(["Poison"]);
         wizard.ManaSpent.ShouldBe(229 + 113 + 73 + 173 + 53);
         wizard.SpellsCast.ShouldBe(spellsToConjure);
     }

--- a/tests/AdventOfCode.Tests/Puzzles/Y2020/Day18Tests.cs
+++ b/tests/AdventOfCode.Tests/Puzzles/Y2020/Day18Tests.cs
@@ -33,7 +33,7 @@ public sealed class Day18Tests(ITestOutputHelper outputHelper) : PuzzleTest(outp
         long expected)
     {
         // Act
-        long actual = Day18.Evaluate(new[] { expression }, version);
+        long actual = Day18.Evaluate([expression], version);
 
         // Assert
         actual.ShouldBe(expected);

--- a/tests/AdventOfCode.Tests/Puzzles/Y2020/Day23Tests.cs
+++ b/tests/AdventOfCode.Tests/Puzzles/Y2020/Day23Tests.cs
@@ -24,7 +24,7 @@ public sealed class Day23Tests(ITestOutputHelper outputHelper) : PuzzleTest(outp
     public void Y2020_Day23_Play_Returns_Correct_Value_Part_2()
     {
         // Arrange
-        IEnumerable<int> arrangement = new[] { 3, 8, 9, 1, 2, 5, 4, 6, 7 }.Concat(Enumerable.Range(10, 999_991));
+        IEnumerable<int> arrangement = [3, 8, 9, 1, 2, 5, 4, 6, 7, ..Enumerable.Range(10, 999_991)];
 
         // Act
         LinkedList<int> actual = Day23.Play(arrangement, moves: 10_000_000);

--- a/tests/AdventOfCode.Tests/Puzzles/Y2022/Day01Tests.cs
+++ b/tests/AdventOfCode.Tests/Puzzles/Y2022/Day01Tests.cs
@@ -32,7 +32,7 @@ public sealed class Day01Tests(ITestOutputHelper outputHelper) : PuzzleTest(outp
 
         // Assert
         actual.ShouldNotBeNull();
-        actual.ShouldBe(new[] { 6000, 4000, 11000, 24000, 10000 });
+        actual.ShouldBe([6000, 4000, 11000, 24000, 10000]);
     }
 
     [Fact]


### PR DESCRIPTION
- Use collection expressions in a few more places.
- Set `[InternalsVisibleTo]` in MSBuild rather than code.
- Make it easy to turn off strong naming to test against code that isn't.
