### PR TITLE
Increase FunctionMemorySize for tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,10 +1,7 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.6.0" />
-    <!--
-    HACK See https://github.com/aws/aws-lambda-dotnet/issues/1594
     <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.9.0" />
-    -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.9" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />

--- a/src/AdventOfCode.Site/AdventOfCode.Site.csproj
+++ b/src/AdventOfCode.Site/AdventOfCode.Site.csproj
@@ -18,10 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" />
-    <!--
-    HACK See https://github.com/aws/aws-lambda-dotnet/issues/1594
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" />
-    -->
     <PackageReference Include="Microsoft.TypeScript.MSBuild" PrivateAssets="all" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>

--- a/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
+++ b/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 namespace MartinCostello.AdventOfCode.Api;
 
 internal sealed class HttpLambdaTestServer()
-    : LambdaTestServer(new LambdaTestServerOptions() { FunctionMemorySize = 8192 }), IAsyncLifetime, ITestOutputHelperAccessor
+    : LambdaTestServer(new LambdaTestServerOptions() { FunctionMemorySize = int.MaxValue }), IAsyncLifetime, ITestOutputHelperAccessor
 {
     private readonly CancellationTokenSource _cts = new();
     private bool _disposed;

--- a/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
+++ b/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
@@ -10,7 +10,8 @@ using Microsoft.Extensions.Logging;
 
 namespace MartinCostello.AdventOfCode.Api;
 
-internal sealed class HttpLambdaTestServer : LambdaTestServer, IAsyncLifetime, ITestOutputHelperAccessor
+internal sealed class HttpLambdaTestServer()
+    : LambdaTestServer(new LambdaTestServerOptions() { FunctionMemorySize = 2048 }), IAsyncLifetime, ITestOutputHelperAccessor
 {
     private readonly CancellationTokenSource _cts = new();
     private bool _disposed;

--- a/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
+++ b/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 namespace MartinCostello.AdventOfCode.Api;
 
 internal sealed class HttpLambdaTestServer()
-    : LambdaTestServer(new LambdaTestServerOptions() { FunctionMemorySize = 4096 }), IAsyncLifetime, ITestOutputHelperAccessor
+    : LambdaTestServer(new LambdaTestServerOptions() { FunctionMemorySize = 8192 }), IAsyncLifetime, ITestOutputHelperAccessor
 {
     private readonly CancellationTokenSource _cts = new();
     private bool _disposed;

--- a/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
+++ b/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 namespace MartinCostello.AdventOfCode.Api;
 
 internal sealed class HttpLambdaTestServer()
-    : LambdaTestServer(new LambdaTestServerOptions() { FunctionMemorySize = 2048 }), IAsyncLifetime, ITestOutputHelperAccessor
+    : LambdaTestServer(new LambdaTestServerOptions() { FunctionMemorySize = 4096 }), IAsyncLifetime, ITestOutputHelperAccessor
 {
     private readonly CancellationTokenSource _cts = new();
     private bool _disposed;

--- a/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
+++ b/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
@@ -11,8 +11,9 @@ using Microsoft.Extensions.Logging;
 namespace MartinCostello.AdventOfCode.Api;
 
 internal sealed class HttpLambdaTestServer()
-    : LambdaTestServer(new LambdaTestServerOptions() { FunctionMemorySize = int.MaxValue }), IAsyncLifetime, ITestOutputHelperAccessor
+    : LambdaTestServer(new LambdaTestServerOptions() { FunctionMemorySize = FunctionMemorySize }), IAsyncLifetime, ITestOutputHelperAccessor
 {
+    private static readonly int FunctionMemorySize = GetFunctionMemorySize();
     private readonly CancellationTokenSource _cts = new();
     private bool _disposed;
     private IWebHost? _webHost;
@@ -61,5 +62,16 @@ internal sealed class HttpLambdaTestServer()
         }
 
         base.Dispose(disposing);
+    }
+
+    private static int GetFunctionMemorySize()
+    {
+        // See https://github.com/aws/aws-lambda-dotnet/issues/1594 and
+        // https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources.
+        return Environment.GetEnvironmentVariable("GITHUB_ACTIONS") switch
+        {
+            "true" => (OperatingSystem.IsMacOS() ? 13 : 6) * 1024, // 1GB less than the runner
+            _ => int.MaxValue,
+        };
     }
 }

--- a/tests/AdventOfCode.Tests/Api/LambdaTests.cs
+++ b/tests/AdventOfCode.Tests/Api/LambdaTests.cs
@@ -50,7 +50,7 @@ public class LambdaTests : IAsyncLifetime, IDisposable
     public async Task InitializeAsync()
         => await _server.InitializeAsync();
 
-    [Fact(Timeout = LambdaTestTimeout)]
+    [RetryFact(Timeout = LambdaTestTimeout)]
     public async Task Can_Get_Puzzle_Metadata()
     {
         // Arrange
@@ -83,7 +83,7 @@ public class LambdaTests : IAsyncLifetime, IDisposable
         }
     }
 
-    [Theory(Timeout = LambdaTestTimeout)]
+    [RetryTheory(Timeout = LambdaTestTimeout)]
     [InlineData(2015, 11, new[] { "cqjxjnds" }, new[] { "cqjxxyzz", "cqkaabcc" })]
     public async Task Can_Solve_Puzzle_With_Input_Arguments(int year, int day, string[] arguments, string[] expected)
     {


### PR DESCRIPTION
Throw even more memory at the problem to try and re-upgrade Amazon.Lambda.RuntimeSupport.
