### PR TITLE
Update lambda tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ env:
   NUGET_XMLDOC_MODE: skip
   PUBLISH_RUNTIME: win-x64
   TERM: xterm
+  # HACK Workaround until changes from martincostello/lambda-test-server#403 can be used
+  AWS_LAMBDA_DOTNET_DISABLE_MEMORY_LIMIT_CHECK: true
 
 permissions:
   contents: read

--- a/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
+++ b/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
@@ -11,9 +11,8 @@ using Microsoft.Extensions.Logging;
 namespace MartinCostello.AdventOfCode.Api;
 
 internal sealed class HttpLambdaTestServer()
-    : LambdaTestServer(new LambdaTestServerOptions() { FunctionMemorySize = FunctionMemorySize }), IAsyncLifetime, ITestOutputHelperAccessor
+    : LambdaTestServer(new LambdaTestServerOptions() { /*DisableMemoryLimitCheck = true*/ }), IAsyncLifetime, ITestOutputHelperAccessor
 {
-    private static readonly int FunctionMemorySize = GetFunctionMemorySize();
     private readonly CancellationTokenSource _cts = new();
     private bool _disposed;
     private IWebHost? _webHost;
@@ -62,16 +61,5 @@ internal sealed class HttpLambdaTestServer()
         }
 
         base.Dispose(disposing);
-    }
-
-    private static int GetFunctionMemorySize()
-    {
-        // See https://github.com/aws/aws-lambda-dotnet/issues/1594 and
-        // https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources.
-        return Environment.GetEnvironmentVariable("GITHUB_ACTIONS") switch
-        {
-            "true" => (OperatingSystem.IsMacOS() ? 13 : 6) * 1024, // 1GB less than the runner
-            _ => int.MaxValue,
-        };
     }
 }


### PR DESCRIPTION
Set `AWS_LAMBDA_DOTNET_DISABLE_MEMORY_LIMIT_CHECK = true` and prepare to set `DisableMemoryLimitCheck = true` in code until the changes from https://github.com/martincostello/lambda-test-server/pull/403 are published to NuGet.org.
