### PR TITLE
Use DisableMemoryLimitCheck

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,6 @@ env:
   NUGET_XMLDOC_MODE: skip
   PUBLISH_RUNTIME: win-x64
   TERM: xterm
-  # HACK Workaround until changes from martincostello/lambda-test-server#403 can be used
-  AWS_LAMBDA_DOTNET_DISABLE_MEMORY_LIMIT_CHECK: true
 
 permissions:
   contents: read

--- a/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
+++ b/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 namespace MartinCostello.AdventOfCode.Api;
 
 internal sealed class HttpLambdaTestServer()
-    : LambdaTestServer(new LambdaTestServerOptions() { /*DisableMemoryLimitCheck = true*/ }), IAsyncLifetime, ITestOutputHelperAccessor
+    : LambdaTestServer(new LambdaTestServerOptions() { DisableMemoryLimitCheck = true }), IAsyncLifetime, ITestOutputHelperAccessor
 {
     private readonly CancellationTokenSource _cts = new();
     private bool _disposed;


### PR DESCRIPTION
Use the new `LambdaTestServerOptions.DisableMemoryLimitCheck` option.
