### PR TITLE
Fix benchmarks

### DIFF
--- a/benchmark.ps1
+++ b/benchmark.ps1
@@ -4,8 +4,6 @@
 #Requires -Version 7
 
 param(
-    [Parameter(Mandatory = $false)][string] $Configuration = "Release",
-    [Parameter(Mandatory = $false)][string] $Framework = "net8.0",
     [Parameter(Mandatory = $false)][string] $Filter = "*",
     [Parameter(Mandatory = $false)][string] $Job = "short"
 )
@@ -89,9 +87,6 @@ if (![string]::IsNullOrEmpty($Job)) {
 
 & $dotnet run `
     --project $benchmarks `
-    --configuration $Configuration `
-    --framework $Framework `
-    --tl `
+    --configuration "Release" `
     -- `
     $additionalArgs
-

--- a/tests/AdventOfCode.Benchmarks/CustomBenchmarkConfig.cs
+++ b/tests/AdventOfCode.Benchmarks/CustomBenchmarkConfig.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+
+namespace MartinCostello.AdventOfCode.Benchmarks;
+
+public class CustomBenchmarkConfig : ManualConfig
+{
+    public CustomBenchmarkConfig()
+        : base()
+    {
+        var job = Job.Default
+            .WithId("AdventOfCode")
+            .WithArguments([new MsBuildArgument("/p:UseArtifactsOutput=false")]);
+
+        AddJob(job);
+        AddDiagnoser(MemoryDiagnoser.Default);
+    }
+}

--- a/tests/AdventOfCode.Benchmarks/PuzzleBenchmarks.cs
+++ b/tests/AdventOfCode.Benchmarks/PuzzleBenchmarks.cs
@@ -3,13 +3,11 @@
 
 using System.Reflection;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Diagnosers;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace MartinCostello.AdventOfCode.Benchmarks;
 
-////[EventPipeProfiler(EventPipeProfile.CpuSampling)] // Appears to hang when run via crank
-[MemoryDiagnoser]
+[Config(typeof(CustomBenchmarkConfig))]
 public class PuzzleBenchmarks
 {
     public static IEnumerable<object> Puzzles()


### PR DESCRIPTION
- Fix `--tl` breaking `dotnet run`.
- Remove `--framework` argument.
- Disable `UseArtifactsOutput` for benchmarks.
