### PR TITLE
Compute once

### DIFF
--- a/src/AdventOfCode/PointExtensions.cs
+++ b/src/AdventOfCode/PointExtensions.cs
@@ -38,20 +38,27 @@ internal static class PointExtensions
     /// </returns>
     public static IEnumerable<Point> Neighbors(this Point value, bool includeSelf = false)
     {
-        yield return new(value.X - 1, value.Y - 1);
-        yield return new(value.X, value.Y - 1);
-        yield return new(value.X + 1, value.Y - 1);
-        yield return new(value.X - 1, value.Y);
+        int y;
+        int x1;
+        int x2 = value.X;
+        int x3;
+
+        yield return new(x1 = x2 - 1, y = value.Y - 1);
+        yield return new(x2 = value.X, y);
+        yield return new(x3 = x2 + 1, y++);
+
+        yield return new(x1, y);
 
         if (includeSelf)
         {
             yield return value;
         }
 
-        yield return new(value.X + 1, value.Y);
-        yield return new(value.X - 1, value.Y + 1);
-        yield return new(value.X, value.Y + 1);
-        yield return new(value.X + 1, value.Y + 1);
+        yield return new(x3, y++);
+
+        yield return new(x1, y);
+        yield return new(x2, y);
+        yield return new(x3, y);
     }
 
     /// <summary>

--- a/tests/AdventOfCode.Benchmarks/PuzzleBenchmarks.cs
+++ b/tests/AdventOfCode.Benchmarks/PuzzleBenchmarks.cs
@@ -182,7 +182,8 @@ public class PuzzleBenchmarks
 
     private static IEnumerable<object> GetPuzzles(
         int year,
-        Dictionary<int, string[]>? inputs = null)
+        Dictionary<int, string[]>? inputs = null,
+        int? day = null)
     {
         var puzzles = typeof(Puzzle).Assembly
             .GetTypes()
@@ -192,6 +193,7 @@ public class PuzzleBenchmarks
             .Where((p) => p.Metadata.Year == year)
             .Where((p) => !p.Metadata.IsHidden)
             .Where((p) => !p.Metadata.IsSlow)
+            .Where((p) => day is null || day.GetValueOrDefault() == p.Metadata.Day)
             .OrderBy((p) => p.Metadata.Year)
             .OrderBy((p) => p.Metadata.Day)
             .ToList();
@@ -209,7 +211,7 @@ public class PuzzleBenchmarks
             }
 
             var puzzleInputOfT = puzzleInput.MakeGenericType(puzzle.Type);
-            yield return Activator.CreateInstance(puzzleInputOfT, new object[] { input })!;
+            yield return Activator.CreateInstance(puzzleInputOfT, [input])!;
         }
     }
 

--- a/tests/AdventOfCode.Tests/Puzzles/Y2022/Day09Tests.cs
+++ b/tests/AdventOfCode.Tests/Puzzles/Y2022/Day09Tests.cs
@@ -60,7 +60,7 @@ public sealed class Day09Tests(ITestOutputHelper outputHelper) : PuzzleTest(outp
 
         foreach (var (direction, initialKnots, finalKnots) in testCases)
         {
-            yield return new object[] { direction, initialKnots, finalKnots };
+            yield return [direction, initialKnots, finalKnots];
         }
     }
 
@@ -119,7 +119,7 @@ public sealed class Day09Tests(ITestOutputHelper outputHelper) : PuzzleTest(outp
 
         foreach (var (direction, initialKnots, finalKnots) in testCases)
         {
-            yield return new object[] { direction, initialKnots, finalKnots };
+            yield return [direction, initialKnots, finalKnots];
         }
 
         static Point[] EmptyPoints(int count) => Enumerable.Repeat(Point.Empty, count).ToArray();


### PR DESCRIPTION
- Compute the coordinates in the `Neighbours()` method just once.
- Add support for short-cutting benchmarks and only running one day.
- Use collection expressions.
