### PR TITLE
Puzzle tweaks

### DIFF
--- a/src/AdventOfCode.Console/Program.cs
+++ b/src/AdventOfCode.Console/Program.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using MartinCostello.AdventOfCode;
 
 var style = NumberStyles.Integer & ~NumberStyles.AllowLeadingSign;
@@ -56,7 +55,7 @@ logger.WriteLine();
 logger.WriteLine($"Advent of Code {year} - Day {day}");
 logger.WriteLine();
 
-var stopwatch = Stopwatch.StartNew();
+long started = TimeProvider.System.GetTimestamp();
 
 try
 {
@@ -73,17 +72,26 @@ catch (PuzzleException ex)
     return -1;
 }
 
-stopwatch.Stop();
+long solved = TimeProvider.System.GetTimestamp();
+var duration = TimeProvider.System.GetElapsedTime(started, solved);
 
 logger.WriteLine();
 
-if (stopwatch.Elapsed.TotalSeconds < 0.01f)
+if (duration.TotalNanoseconds < 1_000)
 {
-    logger.WriteLine("Took <0.01 seconds.");
+    logger.WriteLine($"Took {duration.Nanoseconds:N2}ns.");
+}
+else if (duration.TotalMicroseconds < 1_000)
+{
+    logger.WriteLine($"Took {duration.TotalMicroseconds:N2}μs.");
+}
+else if (duration.TotalMilliseconds < 1_000)
+{
+    logger.WriteLine($"Took {duration.TotalMilliseconds:N2}ms.");
 }
 else
 {
-    logger.WriteLine($"Took {stopwatch.Elapsed.TotalSeconds:N2} seconds.");
+    logger.WriteLine($"Took {duration.TotalSeconds:N2}s.");
 }
 
 logger.WriteLine();

--- a/src/AdventOfCode/Puzzles/Y2020/Day07.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day07.cs
@@ -170,7 +170,7 @@ public sealed class Day07 : Puzzle
 
             string[] split = contents.Split(", ");
 
-            var bagColors = colors[thisColor] = new Dictionary<string, int>();
+            var bagColors = colors[thisColor] = [];
 
             foreach (string bag in split)
             {

--- a/src/AdventOfCode/Puzzles/Y2023/Day03.cs
+++ b/src/AdventOfCode/Puzzles/Y2023/Day03.cs
@@ -74,8 +74,7 @@ public sealed class Day03 : Puzzle
 
                     if (!partsByRow.TryGetValue(y, out var rowParts))
                     {
-                        rowParts = [];
-                        partsByRow[y] = rowParts;
+                        partsByRow[y] = rowParts = [];
                     }
 
                     rowParts.Add((partNumber, locations));

--- a/src/AdventOfCode/Puzzles/Y2023/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2023/Day04.cs
@@ -34,10 +34,11 @@ public sealed class Day04 : Puzzle
 
         int totalPoints = 0;
 
-        foreach (string scratchcard in scratchcards)
+        foreach (string value in scratchcards)
         {
-            int index = scratchcard.IndexOf(':', StringComparison.Ordinal);
-            int card = Parse<int>(scratchcard.AsSpan(5, index - 5), NumberStyles.AllowLeadingWhite);
+            var scratchcard = value.AsSpan();
+            int index = scratchcard.IndexOf(':');
+            int card = Parse<int>(scratchcard[5..index], NumberStyles.AllowLeadingWhite);
 
             (string winningNumbers, string numbersHave) = scratchcard[(index + 1)..].Bifurcate('|');
 


### PR DESCRIPTION
- Print in nanoseconds, microseconds or milliseconds when the puzzle is solved fast enough.
- Use collection expressions.
- Assign two variables on one line.
- Use span to index, rather than the string itself.
