### PR TITLE
Optimise days 14 & 15 for 2023

### DIFF
--- a/src/AdventOfCode/Puzzles/Y2023/Day15.cs
+++ b/src/AdventOfCode/Puzzles/Y2023/Day15.cs
@@ -60,7 +60,6 @@ public sealed class Day15 : Puzzle
     {
         var boxes = new List<Lens>[Boxes];
 
-        int power = 0;
         int next;
 
         while ((next = sequence.IndexOf(',')) != -1)
@@ -70,6 +69,8 @@ public sealed class Day15 : Puzzle
         }
 
         Shuffle(sequence, sequence.Length, boxes);
+
+        int power = 0;
 
         for (int j = 0; j < boxes.Length; j++)
         {

--- a/src/AdventOfCode/Puzzles/Y2023/Day15.cs
+++ b/src/AdventOfCode/Puzzles/Y2023/Day15.cs
@@ -71,8 +71,9 @@ public sealed class Day15 : Puzzle
         Shuffle(sequence, sequence.Length, boxes);
 
         int power = 0;
+        int length = boxes.Length;
 
-        for (int j = 0; j < boxes.Length; j++)
+        for (int j = 0; j < length; j++)
         {
             if (boxes[j] is not { } lenses)
             {


### PR DESCRIPTION
- Remove LINQ.
- Use array instead of dictionary.
- Use hash code for label instead of allocating a string.
- Fix allocation size for boxes.
- Hash the state while sliding, rather than separately.