### PR TITLE
Increase maximum body size

### DIFF
--- a/src/AdventOfCode.Site/Program.cs
+++ b/src/AdventOfCode.Site/Program.cs
@@ -16,7 +16,7 @@ builder.WebHost.CaptureStartupErrors(true);
 builder.WebHost.ConfigureKestrel((p) =>
 {
     p.AddServerHeader = false;
-    p.Limits.MaxRequestBodySize = 10 * 1024; // Maximum upload file size of 10KB
+    p.Limits.MaxRequestBodySize = 200 * 1024; // Maximum upload file size of 200KB
 });
 
 builder.Services.AddSingleton<ICache>((_) => NullCache.Instance);


### PR DESCRIPTION
The largest file is 180KB and today's is 22KB, so 10KB is too small.
