### PR TITLE
Increase maximum body size

### DIFF
--- a/src/AdventOfCode.Site/web.config
+++ b/src/AdventOfCode.Site/web.config
@@ -18,7 +18,7 @@
     </httpProtocol>
     <security>
       <requestFiltering removeServerHeader="true">
-        <requestLimits maxAllowedContentLength="10240" />
+        <requestLimits maxAllowedContentLength="204800" />
       </requestFiltering>
     </security>
     <urlCompression doDynamicCompression="true" doStaticCompression="true" />


### PR DESCRIPTION
The largest file is 180KB and today's is 22KB, so 10KB is too small.

