### PR TITLE
Add Unsolved attribute

### DIFF
--- a/src/AdventOfCode.Console/PuzzleSolver.cs
+++ b/src/AdventOfCode.Console/PuzzleSolver.cs
@@ -144,7 +144,7 @@ public sealed class PuzzleSolver
                 var puzzle = factory.Create(year, day);
 
                 if (puzzle.GetType().GetCustomAttribute<PuzzleAttribute>() is { } metadata &&
-                    (metadata.IsHidden || metadata.IsSlow || metadata.MinimumArguments > 0))
+                    (metadata.IsHidden || metadata.IsSlow || metadata.Unsolved || metadata.MinimumArguments > 0))
                 {
                     continue;
                 }

--- a/src/AdventOfCode.Site/Program.cs
+++ b/src/AdventOfCode.Site/Program.cs
@@ -30,7 +30,9 @@ var puzzles = typeof(Puzzle).Assembly
     .Where((p) => p.IsAssignableTo(typeof(Puzzle)))
     .Select((p) => p.GetCustomAttribute<PuzzleAttribute>())
     .Where((p) => p is not null)
-    .Where((p) => !p!.IsHidden)
+    .Cast<PuzzleAttribute>()
+    .Where((p) => !p.IsHidden)
+    .Where((p) => !p.Unsolved)
     .ToList();
 
 foreach (var puzzle in puzzles)

--- a/src/AdventOfCode/PuzzleAttribute.cs
+++ b/src/AdventOfCode/PuzzleAttribute.cs
@@ -40,6 +40,11 @@ public sealed class PuzzleAttribute(int year, int day, string name) : Attribute
     public bool RequiresData { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the puzzle is unsolved.
+    /// </summary>
+    public bool Unsolved { get; set; }
+
+    /// <summary>
     /// Gets the year associated with the puzzle.
     /// </summary>
     public int Year { get; } = year;

--- a/tests/AdventOfCode.Benchmarks/PuzzleBenchmarks.cs
+++ b/tests/AdventOfCode.Benchmarks/PuzzleBenchmarks.cs
@@ -193,6 +193,7 @@ public class PuzzleBenchmarks
             .Where((p) => p.Metadata.Year == year)
             .Where((p) => !p.Metadata.IsHidden)
             .Where((p) => !p.Metadata.IsSlow)
+            .Where((p) => !p.Metadata.Unsolved)
             .Where((p) => day is null || day.GetValueOrDefault() == p.Metadata.Day)
             .OrderBy((p) => p.Metadata.Year)
             .OrderBy((p) => p.Metadata.Day)

--- a/tests/AdventOfCode.Tests/Puzzles/Y2023/Day10Tests.cs
+++ b/tests/AdventOfCode.Tests/Puzzles/Y2023/Day10Tests.cs
@@ -95,7 +95,7 @@ public sealed class Day10Tests(ITestOutputHelper outputHelper) : PuzzleTest(outp
         actual.ShouldBe(4);
     }
 
-    [Fact(Skip = "Not working due to bug.")]
+    [Fact(Skip = "Unsolved.")]
     public void Y2023_Day10_Walk_Returns_Correct_Value_For_Tiles_3()
     {
         // Arrange


### PR DESCRIPTION
Add property to signal a puzzle as explicitly unsolved.

