### PR TITLE
Use collection expression

### DIFF
--- a/tests/AdventOfCode.Tests/Api/LambdaTests.cs
+++ b/tests/AdventOfCode.Tests/Api/LambdaTests.cs
@@ -261,7 +261,7 @@ public class LambdaTests : IAsyncLifetime, IDisposable
             {
                 try
                 {
-                    typeof(Site.Program).Assembly.EntryPoint!.Invoke(null, new[] { Array.Empty<string>() });
+                    typeof(Site.Program).Assembly.EntryPoint!.Invoke(null, []);
                 }
                 catch (Exception ex) when (LambdaServerWasShutDown(ex))
                 {


### PR DESCRIPTION
Use collection expression to fix new analyser warning in .NET 9 (see #1464).
