### PR TITLE
Add .NET tools manifest

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "amazon.lambda.tools": {
+      "version": "5.10.3",
+      "commands": [
+        "dotnet-lambda"
+      ]
+    }
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,9 +89,9 @@ jobs:
           ~/.cache/ms-playwright
           ~/Library/Caches/ms-playwright
 
-    - name: Install .NET Lambda tool
+    - name: Install .NET tools
       shell: pwsh
-      run: dotnet tool install --global Amazon.Lambda.Tools
+      run: dotnet tool restore
 
     - name: Build, test and publish
       shell: pwsh
@@ -287,9 +287,9 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
 
-    - name: Install .NET Lambda tool
+    - name: Install .NET tools
       shell: pwsh
-      run: dotnet tool install --global Amazon.Lambda.Tools
+      run: dotnet tool restore
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/build.ps1
+++ b/build.ps1
@@ -127,7 +127,7 @@ if ($SkipPublish -eq $false) {
 
     $packageFile = Join-Path $PSScriptRoot "artifacts" "publish" "lambda.zip"
 
-    # Requires that `dotnet tool install --global Amazon.Lambda.Tools` is run first
+    # Requires that `dotnet tool restore` is run first
     dotnet-lambda `
         package `
         --output-package $packageFile `


### PR DESCRIPTION
Consume Amazon.Lambda.Tools as a local tool so that a specific version can be installed and updated with dependabot.
