### PR TITLE
Deploy container to App Service

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ env:
   AWS_URL_PROD: https://aoc.martincostello.com/
   AZURE_URL_PROD: https://advent--of--code.azurewebsites.net/
   AZURE_WEBAPP_NAME: advent--of--code
+  CONTAINER_REGISTRY: '${{ github.repository_owner }}.azurecr.io'
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_GENERATE_ASPNET_CERTIFICATE: false
   DOTNET_MULTILEVEL_LOOKUP: 0
@@ -39,7 +40,12 @@ jobs:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
+    env:
+      PUBLISH_CONTAINER: ${{ github.event.repository.fork == false && github.ref_name == github.event.repository.default_branch && matrix.os == 'ubuntu-latest' }}
+
     outputs:
+      container-image: ${{ steps.publish-container.outputs.container-image }}
+      container-tag: ${{ steps.publish-container.outputs.container-tag }}
       lambda-tools-version: ${{ steps.get-lambda-tools-version.outputs.lambda-tools-version }}
 
     strategy:
@@ -140,6 +146,24 @@ jobs:
         path: ./artifacts/videos/*
         if-no-files-found: ignore
 
+    - name: Docker log in
+      uses: azure/docker-login@v1
+      if: env.PUBLISH_CONTAINER == 'true'
+      with:
+        login-server: ${{ env.CONTAINER_REGISTRY }}
+        username: ${{ secrets.ACR_REGISTRY_USERNAME }}
+        password: ${{ secrets.ACR_REGISTRY_PASSWORD }}
+
+    - name: Publish container
+      id: publish-container
+      if: env.PUBLISH_CONTAINER == 'true'
+      shell: pwsh
+      run: |
+        dotnet publish ./src/AdventOfCode.Site --arch x64 --os linux -p:PublishProfile=DefaultContainer
+        $containerImage = "${env:CONTAINER_REGISTRY}/${env:GITHUB_REPOSITORY}"
+        "container-image=${containerImage}" >> "${env:GITHUB_OUTPUT}"
+        "container-tag=${containerImage}:github-${env:GITHUB_RUN_NUMBER}" >> "${env:GITHUB_OUTPUT}"
+
     - name: Get Amazon Lambda tools version
       id: get-lambda-tools-version
       shell: pwsh
@@ -214,11 +238,18 @@ jobs:
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-    - name: Deploy to Azure App Service
+    - name: Deploy application to Azure App Service
       uses: azure/webapps-deploy@v3
       id: deploy_production
       with:
         app-name: ${{ env.AZURE_WEBAPP_NAME }}
+
+    - name: Deploy container to Azure App Service
+      uses: azure/webapps-deploy@v3
+      if: needs.build.outputs.container-tag != ''
+      with:
+        app-name: 'adventofcode-martincostello'
+        images: ${{ needs.build.outputs.container-tag }}
 
   test:
     name: test-production

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,6 +33,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags></PackageTags>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <PublishForAWSLambda>false</PublishForAWSLambda>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>

--- a/src/AdventOfCode.Site/AdventOfCode.Site.csproj
+++ b/src/AdventOfCode.Site/AdventOfCode.Site.csproj
@@ -13,9 +13,29 @@
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
     <TypeScriptToolsVersion>latest</TypeScriptToolsVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(RuntimeIdentifier)' == 'linux-arm64' ">
+  <PropertyGroup Condition=" '$(PublishForAWSLambda)' == 'true' ">
     <AssemblyName>bootstrap</AssemblyName>
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <RuntimeIdentifier>linux-arm64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(CI)' == 'true' ">
+    <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
+    <ContainerBaseImage>mcr.microsoft.com/dotnet/nightly/runtime-deps:8.0-noble-chiseled-extra</ContainerBaseImage>
+    <ContainerImageTags>github-$(GITHUB_RUN_NUMBER);latest</ContainerImageTags>
+    <ContainerRegistry>$(GITHUB_REPOSITORY_OWNER).azurecr.io</ContainerRegistry>
+    <ContainerRepository>$(GITHUB_REPOSITORY)</ContainerRepository>
+    <ContainerTitle>$(GITHUB_REPOSITORY)</ContainerTitle>
+    <ContainerVendor>$(GITHUB_REPOSITORY_OWNER)</ContainerVendor>
+    <ContainerVersion>$(GITHUB_SHA)</ContainerVersion>
+    <PublishSelfContained>true</PublishSelfContained>
+  </PropertyGroup>
+  <ItemGroup Condition=" '$(CI)' == 'true' ">
+    <ContainerLabel Include="com.docker.extension.changelog" Value="$(GITHUB_SERVER_URL)/$(GITHUB_REPOSITORY)/commit/$(GITHUB_SHA)" />
+    <ContainerLabel Include="com.docker.extension.publisher-url" Value="$(GITHUB_SERVER_URL)/$(GITHUB_REPOSITORY_OWNER)" />
+    <ContainerPort Include="8080" Type="tcp" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" />
     <PackageReference Include="Amazon.Lambda.RuntimeSupport" />
@@ -43,10 +63,10 @@
     <Exec Command="npm install" Condition=" !Exists('$(MSBuildThisFileDirectory)\node_modules') AND '$(GITHUB_ACTIONS)' == '' " />
     <Exec Command="npm run publish" Condition=" !Exists('$(MSBuildThisFileDirectory)\wwwroot\static\js\main.js') " />
   </Target>
-  <ItemGroup Condition=" '$(RuntimeIdentifier)' == 'linux-arm64' ">
+  <ItemGroup Condition=" '$(PublishForAWSLambda)' == 'true' ">
     <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" />
   </ItemGroup>
-  <Target Name="SetAppLocalIcuVersion" BeforeTargets="Compile" Condition=" '$(RuntimeIdentifier)' == 'linux-arm64' ">
+  <Target Name="SetAppLocalIcuVersion" BeforeTargets="Compile" Condition=" '$(PublishForAWSLambda)' == 'true' ">
     <ItemGroup>
       <RuntimeHostConfigurationOption Condition=" '%(PackageVersion.Identity)' == 'Microsoft.ICU.ICU4C.Runtime' " Include="System.Globalization.AppLocalIcu" Value="%(PackageVersion.Version)" />
     </ItemGroup>

--- a/src/AdventOfCode.Site/aws-lambda-tools-defaults.json
+++ b/src/AdventOfCode.Site/aws-lambda-tools-defaults.json
@@ -10,7 +10,7 @@
   "function-name": "adventofcode",
   "function-runtime": "provided.al2023",
   "function-timeout": 30,
-  "msbuild-parameters": "--runtime linux-arm64 --self-contained true /p:PublishReadyToRun=true /p:TieredCompilation=false",
+  "msbuild-parameters": "/p:PublishForAWSLambda=true",
   "package-type": "Zip",
   "runtime": "linux-arm64",
   "s3-bucket": "adventofcode",


### PR DESCRIPTION
- Deploy a container to Azure App Service.
- Move publishing properties for AWS Lambda into the project file and enable with a single property override.

