### PR TITLE
Avoid deadlock

### DIFF
--- a/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
+++ b/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
@@ -17,6 +17,8 @@ internal sealed class HttpLambdaTestServer()
     private bool _disposed;
     private IWebHost? _webHost;
 
+    public CancellationToken CancellationToken => _cts.Token;
+
     public ITestOutputHelper? OutputHelper { get; set; }
 
     public async Task DisposeAsync()

--- a/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
+++ b/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
@@ -25,7 +25,16 @@ internal sealed class HttpLambdaTestServer()
     {
         if (_webHost is not null)
         {
-            await _webHost.StopAsync();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+            try
+            {
+                await _webHost.StopAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Took too long
+            }
         }
 
         Dispose();

--- a/tests/AdventOfCode.Tests/Api/LambdaTests.cs
+++ b/tests/AdventOfCode.Tests/Api/LambdaTests.cs
@@ -280,7 +280,7 @@ public class LambdaTests : IAsyncLifetime, IDisposable
 
         context.Response.TryRead(out LambdaTestResponse? response).ShouldBeTrue();
         response.IsSuccessful.ShouldBeTrue($"Failed to process request: {await response.ReadAsStringAsync()}");
-        response.Duration.ShouldBeInRange(TimeSpan.Zero, TimeSpan.FromSeconds(2));
+        response.Duration.ShouldBeInRange(TimeSpan.Zero, TimeSpan.FromSeconds(3));
         response.Content.ShouldNotBeEmpty();
 
         // Assert


### PR DESCRIPTION
- Try and avoid a test deadlock by cancelling the token after the server is started.
- Update assertion range to match the `CancellationToken`.
- Only give the Lambda test server 2 seconds to shut down, rather than waiting indefinitely.
