### PR TITLE
Disable IDE0130

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -34,6 +34,7 @@ dotnet_diagnostic.IDE0046.severity = silent
 dotnet_diagnostic.IDE0058.severity = silent
 dotnet_diagnostic.IDE0072.severity = silent
 dotnet_diagnostic.IDE0079.severity = silent
+dotnet_diagnostic.IDE0130.severity = silent
 
 # Organize usings
 dotnet_sort_system_directives_first = true


### PR DESCRIPTION
Disable new IDE0130 rule being added for .NET 9 preview 6.
