### PR TITLE
Refactor some puzzles

### DIFF
--- a/benchmark.ps1
+++ b/benchmark.ps1
@@ -5,7 +5,7 @@
 
 param(
     [Parameter(Mandatory = $false)][string] $Filter = "*",
-    [Parameter(Mandatory = $false)][string] $Job = "short"
+    [Parameter(Mandatory = $false)][string] $Job = ""
 )
 
 $ErrorActionPreference = "Stop"

--- a/src/AdventOfCode/EnumerableExtensions.cs
+++ b/src/AdventOfCode/EnumerableExtensions.cs
@@ -67,4 +67,16 @@ internal static class EnumerableExtensions
             previous = enumerator.Current;
         }
     }
+
+    /// <summary>
+    /// Returns the product of the specified sequence of numbers.
+    /// </summary>
+    /// <typeparam name="T">The type of the numbers.</typeparam>
+    /// <param name="source">The source to enumerate for numbers.</param>
+    /// <returns>
+    /// The product of the specified sequence of numbers.
+    /// </returns>
+    public static T Product<T>(this IEnumerable<T> source)
+        where T : IMultiplyOperators<T, T, T>
+        => source.Aggregate(static (x, y) => x * y);
 }

--- a/src/AdventOfCode/PointExtensions.cs
+++ b/src/AdventOfCode/PointExtensions.cs
@@ -23,17 +23,12 @@ internal static class PointExtensions
         // See https://en.wikipedia.org/wiki/Shoelace_formula
         long crossProductSum = vertices
             .Pairwise(CrossProduct)
-            .Aggregate(1L, (x, y) => x + y);
+            .Sum();
 
-        return Math.Abs(crossProductSum) / 2;
+        return Math.Abs(crossProductSum + 1) / 2;
 
         static long CrossProduct(Point i, Point j)
-        {
-            long ix = i.X;
-            long jx = j.X;
-
-            return (ix * j.Y) - (jx * i.Y);
-        }
+            => Math.BigMul(i.X, j.Y) - Math.BigMul(j.X, i.Y);
     }
 
     /// <summary>

--- a/src/AdventOfCode/Puzzles/Y2015/Day24.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day24.cs
@@ -35,7 +35,7 @@ public sealed class Day24 : Puzzle
         int total = weights.Sum() / compartments;
 
         var optimumConfiguration = Maths.GetCombinations(total, weights)
-            .Select((p) => new { p.Count, QuantumEntanglement = p.Aggregate((x, y) => x * y) })
+            .Select((p) => new { p.Count, QuantumEntanglement = p.Product() })
             .OrderBy((p) => p.Count)
             .ThenBy((p) => p.QuantumEntanglement)
             .First();

--- a/src/AdventOfCode/Puzzles/Y2020/Day01.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day01.cs
@@ -49,7 +49,7 @@ public sealed class Day01 : Puzzle
 
                 return sum is 2020;
             })
-            .Select((p) => p.Aggregate((x, y) => x * y))
+            .Select((p) => p.Product())
             .First();
     }
 

--- a/src/AdventOfCode/Puzzles/Y2020/Day16.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day16.cs
@@ -183,7 +183,7 @@ public sealed class Day16 : Puzzle
         DepartureProduct = ticket
             .Where((p) => p.Key.AsSpan().StartsWith("departure"))
             .Select((p) => (long)p.Value)
-            .Aggregate((x, y) => x * y);
+            .Product();
 
         if (Verbose)
         {

--- a/src/AdventOfCode/Puzzles/Y2021/Day09.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day09.cs
@@ -99,14 +99,12 @@ public sealed class Day09 : Puzzle
             basinAreas.Add(basin.Count);
         }
 
-        int sumOfRiskLevels = lowPoints.Values
-            .Select((p) => p + 1)
-            .Sum();
+        int sumOfRiskLevels = lowPoints.Values.Sum() + lowPoints.Count;
 
         int areaOfThreeLargestBasins = basinAreas
             .OrderDescending()
             .Take(3)
-            .Aggregate((x, y) => x *= y);
+            .Product();
 
         return (sumOfRiskLevels, areaOfThreeLargestBasins);
     }

--- a/tests/AdventOfCode.Benchmarks/CustomBenchmarkConfig.cs
+++ b/tests/AdventOfCode.Benchmarks/CustomBenchmarkConfig.cs
@@ -12,7 +12,7 @@ public class CustomBenchmarkConfig : ManualConfig
     public CustomBenchmarkConfig()
         : base()
     {
-        var job = Job.Default
+        var job = Job.ShortRun
             .WithId("AdventOfCode")
             .WithArguments([new MsBuildArgument("/p:UseArtifactsOutput=false")]);
 


### PR DESCRIPTION
- Use `Match.BigMul()` to simplify cross product of vectors.
- Add `Product()` extension method for numeric types.
- Use `Sum() + 1` instead of `Aggregate()` with a seed of 1.
- Remove redundant `Select()`.
