### PR TITLE
Fix duplicate benchmarks

### DIFF
--- a/crank.yml
+++ b/crank.yml
@@ -11,8 +11,7 @@ jobs:
       project: tests/AdventOfCode.Benchmarks/AdventOfCode.Benchmarks.csproj
     variables:
       filterArg: "*"
-      jobArg: short
-    arguments: --job {{jobArg}} --filter {{filterArg}} --memory
+    arguments: --filter {{filterArg}} --memory
     channel: current
     options:
       benchmarkDotNet: true


### PR DESCRIPTION
- Default to the short run, rather than duplicating via `--job short`.
