### PR TITLE
More use of span

### DIFF
--- a/src/AdventOfCode/DictionaryExtensions.cs
+++ b/src/AdventOfCode/DictionaryExtensions.cs
@@ -103,4 +103,105 @@ internal static class DictionaryExtensions
 
         return result;
     }
+
+    /// <summary>
+    /// Increments the value of the specified key, or adds it if not already present.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="alternate">The dictionary to add or increment the value for.</param>
+    /// <param name="key">The key to increment the value of or add to the dictionary.</param>
+    /// <param name="value">The value to add to the dictionary if the key is not found.</param>
+    public static void AddOrIncrement<TValue>(this Dictionary<string, TValue>.AlternateLookup<ReadOnlySpan<char>> alternate, ReadOnlySpan<char> key, TValue value)
+        where TValue : INumber<TValue>
+        => alternate.AddOrIncrement(key, value, TValue.One);
+
+    /// <summary>
+    /// Increments the value of the specified key by the specified value, or adds it if not already present.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="alternate">The dictionary to add or increment the value for.</param>
+    /// <param name="key">The key to increment the value of or add to the dictionary.</param>
+    /// <param name="value">The value to add to the dictionary if the key is not found.</param>
+    /// <param name="increment">The value to increment by.</param>
+    public static void AddOrIncrement<TValue>(this Dictionary<string, TValue>.AlternateLookup<ReadOnlySpan<char>> alternate, ReadOnlySpan<char> key, TValue value, TValue increment)
+        where TValue : INumber<TValue> =>
+        alternate[key] = alternate.TryGetValue(key, out var current) ? current + increment : value;
+
+    /// <summary>
+    /// Decrements the value of the specified key, or adds it if not already present.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="alternate">The dictionary to add or decrement the value for.</param>
+    /// <param name="key">The key to decrement the value of or add to the dictionary.</param>
+    /// <param name="value">The value to add to the dictionary if the key is not found.</param>
+    public static void AddOrDecrement<TValue>(this Dictionary<string, TValue>.AlternateLookup<ReadOnlySpan<char>> alternate, ReadOnlySpan<char> key, TValue value)
+        where TValue : INumber<TValue>
+        => alternate.AddOrDecrement(key, value, TValue.One);
+
+    /// <summary>
+    /// Decrements the value of the specified key by the specified value, or adds it if not already present.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="alternate">The dictionary to add or decrement the value for.</param>
+    /// <param name="key">The key to decrement the value of or add to the dictionary.</param>
+    /// <param name="value">The value to add to the dictionary if the key is not found.</param>
+    /// <param name="decrement">The value to decrement by.</param>
+    public static void AddOrDecrement<TValue>(this Dictionary<string, TValue>.AlternateLookup<ReadOnlySpan<char>> alternate, ReadOnlySpan<char> key, TValue value, TValue decrement)
+        where TValue : INumber<TValue>
+        => alternate[key] = alternate.TryGetValue(key, out var current) ? current - decrement : value;
+
+    /// <summary>
+    /// Gets the reference with the specified key, adding it if not already present.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="alternate">The dictionary to get the reference for.</param>
+    /// <param name="key">The key to get the reference for.</param>
+    /// <param name="factory">A delegate to a method to create the reference if not found.</param>
+    /// <returns>
+    /// The value reference with the specified key.
+    /// </returns>
+    public static TValue GetOrAdd<TValue>(
+        this Dictionary<string, TValue>.AlternateLookup<ReadOnlySpan<char>> alternate,
+        ReadOnlySpan<char> key,
+        Func<TValue> factory)
+        where TValue : class
+    {
+        if (!alternate.TryGetValue(key, out var result))
+        {
+            result = alternate[key] = factory();
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Gets the reference with the specified key, adding it if not already present.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="alternate">The dictionary alternate lookup to get the reference for.</param>
+    /// <param name="key">The key to get the reference for.</param>
+    /// <returns>
+    /// The value reference with the specified key.
+    /// </returns>
+    public static TValue GetOrAdd<TValue>(this Dictionary<string, TValue>.AlternateLookup<ReadOnlySpan<char>> alternate, ReadOnlySpan<char> key)
+        where TValue : class, new()
+    {
+        if (!alternate.TryGetValue(key, out var result))
+        {
+            result = alternate[key] = new();
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="ReadOnlySpan{T}"/> alternate lookup for the specified dictionary of strings.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="dictionary">The dictionary to get the alternate lookup for.</param>
+    /// <returns>
+    /// The alternate lookup for spans for the specified dictionary.
+    /// </returns>
+    public static Dictionary<string, TValue>.AlternateLookup<ReadOnlySpan<char>> GetAlternateLookup<TValue>(this Dictionary<string, TValue> dictionary)
+        => dictionary.GetAlternateLookup<ReadOnlySpan<char>>();
 }

--- a/src/AdventOfCode/Puzzles/Y2015/Day05.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day05.cs
@@ -33,10 +33,10 @@ public sealed class Day05 : Puzzle
     /// <returns>
     /// <see langword="true"/> if <paramref name="value"/> is 'nice'; otherwise <see langword="false"/>.
     /// </returns>
-    public static bool IsNiceV1(string value)
+    public static bool IsNiceV1(ReadOnlySpan<char> value)
     {
         // The string is not nice if it contain any of the following sequences
-        if (value.AsSpan().ContainsAny(NotNiceSequences))
+        if (value.ContainsAny(NotNiceSequences))
         {
             return false;
         }
@@ -105,12 +105,11 @@ public sealed class Day05 : Puzzle
     internal static bool HasPairOfLettersWithMoreThanOneOccurrence(ReadOnlySpan<char> value)
     {
         var letterPairs = new Dictionary<string, List<int>>();
+        var alternate = letterPairs.GetAlternateLookup();
 
         for (int i = 0; i < value.Length - 1; i++)
         {
-            string pair = new(value.Slice(i, 2));
-
-            var indexes = letterPairs.GetOrAdd(pair);
+            var indexes = alternate.GetOrAdd(value.Slice(i, 2));
 
             if (!indexes.Contains(i - 1))
             {
@@ -128,7 +127,7 @@ public sealed class Day05 : Puzzle
     /// <returns>
     /// <see langword="true"/> if <paramref name="value"/> meets the rule; otherwise <see langword="false"/>.
     /// </returns>
-    internal static bool HasLetterThatIsTheBreadOfALetterSandwich(string value)
+    internal static bool HasLetterThatIsTheBreadOfALetterSandwich(ReadOnlySpan<char> value)
     {
         if (value.Length < 3)
         {
@@ -152,7 +151,7 @@ public sealed class Day05 : Puzzle
     {
         var values = await ReadResourceAsLinesAsync(cancellationToken);
 
-        NiceStringCountV1 = values.Count(IsNiceV1);
+        NiceStringCountV1 = values.Count((p) => IsNiceV1(p));
         NiceStringCountV2 = values.Count(IsNiceV2);
 
         if (Verbose)

--- a/src/AdventOfCode/Puzzles/Y2015/Day07.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day07.cs
@@ -63,7 +63,7 @@ public sealed class Day07 : Puzzle
                         result[wireId] = value;
                     }
                 }
-                else if (words.Length == 2 && firstOperand == "NOT")
+                else if (words.Length == 2 && firstOperand is "NOT")
                 {
                     // "NOT e -> f" or "NOT 1 -> g"
                     secondOperand = words.ElementAtOrDefault(1);
@@ -139,7 +139,7 @@ public sealed class Day07 : Puzzle
     /// <returns>
     /// The solved value for the specified parameters if solved; otherwise <see langword="null"/>.
     /// </returns>
-    private static ushort? TrySolveValueForOperation(string operation, ushort firstValue, ushort secondValue)
+    private static ushort? TrySolveValueForOperation(ReadOnlySpan<char> operation, ushort firstValue, ushort secondValue)
     {
         return operation switch
         {

--- a/src/AdventOfCode/Puzzles/Y2015/Day08.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day08.cs
@@ -78,8 +78,8 @@ public sealed class Day08 : Puzzle
         int count = 0;
 
         // Remove quotes if present as first/last characters
-        bool removeFirstQuote = value.Length > 0 && value[0] == '\"';
-        bool removeLastQuote = value.Length > 1 && value[^1] == '\"';
+        bool removeFirstQuote = value.Length > 0 && value[0] is '\"';
+        bool removeLastQuote = value.Length > 1 && value[^1] is '\"';
 
         if (removeFirstQuote)
         {
@@ -93,7 +93,7 @@ public sealed class Day08 : Puzzle
 
         if (value.Length > 0)
         {
-            var characters = new Queue<char>(new string(value));
+            var characters = new Queue<char>(value.ToString());
 
             while (characters.Count > 0)
             {

--- a/src/AdventOfCode/Puzzles/Y2015/Day09.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day09.cs
@@ -35,15 +35,12 @@ public sealed class Day09 : Puzzle
 
         for (int i = 0; i < collection.Count; i++)
         {
-            string[] split = collection[i].Split(" = ");
-            string[] locations = split[0].Split(" to ");
-
-            string start = locations[0];
-            string end = locations[1];
+            collection[i].AsSpan().Bifurcate(" = ", out var first, out var second);
+            (string start, string end) = first.ToString().Bifurcate(" to ");
 
             vectors[i] = (start, end);
 
-            int distance = Parse<int>(split[1]);
+            int distance = Parse<int>(second);
 
             distances[$"{start} to {end}"] = distance;
             distances[$"{end} to {start}"] = distance;

--- a/src/AdventOfCode/Puzzles/Y2015/Day11.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day11.cs
@@ -34,7 +34,7 @@ public sealed class Day11 : Puzzle
         }
         while (!(ContainsTriumvirateOfLetters(next) && ContainsNoForbiddenCharacters(next) && HasMoreThanOneDistinctPairOfLetters(next)));
 
-        return new string(next);
+        return next.ToString();
     }
 
     /// <summary>
@@ -70,6 +70,7 @@ public sealed class Day11 : Puzzle
     public static bool HasMoreThanOneDistinctPairOfLetters(ReadOnlySpan<char> value)
     {
         var letterPairs = new Dictionary<string, List<int>>();
+        var alternate = letterPairs.GetAlternateLookup();
 
         for (int i = 0; i < value.Length - 1; i++)
         {
@@ -83,7 +84,7 @@ public sealed class Day11 : Puzzle
 
             string pair = new(value.Slice(i, 2));
 
-            var indexes = letterPairs.GetOrAdd(pair);
+            var indexes = alternate.GetOrAdd(pair);
 
             if (!indexes.Contains(i - 1))
             {
@@ -121,7 +122,7 @@ public sealed class Day11 : Puzzle
 
         for (int i = value.Length - 1; !done && i > -1; i--)
         {
-            if (value[i] == 'z')
+            if (value[i] is 'z')
             {
                 value[i] = 'a';
             }

--- a/src/AdventOfCode/Puzzles/Y2015/Day16.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day16.cs
@@ -145,15 +145,18 @@ public sealed class Day16 : Puzzle
         internal static AuntSue Parse(string value)
         {
             var result = new AuntSue();
+            var alternate = result.Metadata.GetAlternateLookup();
 
             string[] split = value.Split(' ');
 
             result.Number = Parse<int>(split[1].TrimEnd(':'));
 
-            foreach (var item in string.Join(' ', split, 2, split.Length - 2).Tokenize(','))
+            var joined = string.Join(' ', split, 2, split.Length - 2).AsSpan();
+
+            foreach (var range in joined.Split(','))
             {
-                item.Bifurcate(':', out var first, out var second);
-                result.Metadata[new(first.Trim())] = Parse<int>(second.Trim());
+                joined[range].Bifurcate(':', out var first, out var second);
+                alternate[first.Trim()] = Parse<int>(second.Trim());
             }
 
             return result;

--- a/src/AdventOfCode/Puzzles/Y2015/Day22.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day22.cs
@@ -199,12 +199,12 @@ public sealed class Day22 : Puzzle
         /// <summary>
         /// Gets the names of the active spells cast by the wizard.
         /// </summary>
-        internal IList<string> ActiveSpells => _spells.Where((p) => p.TurnsLeft > 0).Select((p) => p.Name).ToArray();
+        internal string[] ActiveSpells => [.. _spells.Where((p) => p.TurnsLeft > 0).Select((p) => p.Name)];
 
         /// <summary>
         /// Gets the names of all the spells cast by the wizard.
         /// </summary>
-        internal IList<string> SpellsCast => _spells.Select((p) => p.Name).ToArray();
+        internal string[] SpellsCast => [.. _spells.Select((p) => p.Name)];
 
         /// <summary>
         /// Gets or sets the amount of mana the wizard has.
@@ -235,7 +235,7 @@ public sealed class Day22 : Puzzle
             }
 
             // Determine which spell the wizard should cast
-            string spellToConjure = _spellSelector(this, availableSpells.Select((p) => p.Key).ToList());
+            string spellToConjure = _spellSelector(this, [.. availableSpells.Select((p) => p.Key)]);
 
             // Get the spell
             SpellInfo info = availableSpells

--- a/src/AdventOfCode/Puzzles/Y2015/Day23.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day23.cs
@@ -54,15 +54,15 @@ public sealed class Day23 : Puzzle
             switch (operation)
             {
                 case "hlf":
-                    (registerOrOffset == "a" ? a : b).Value /= 2;
+                    (registerOrOffset is "a" ? a : b).Value /= 2;
                     break;
 
                 case "tpl":
-                    (registerOrOffset == "a" ? a : b).Value *= 3;
+                    (registerOrOffset is "a" ? a : b).Value *= 3;
                     break;
 
                 case "inc":
-                    (registerOrOffset == "a" ? a : b).Value++;
+                    (registerOrOffset is "a" ? a : b).Value++;
                     break;
 
                 case "jmp":
@@ -70,7 +70,7 @@ public sealed class Day23 : Puzzle
                     break;
 
                 case "jie":
-                    if ((registerOrOffset!.Split(',')[0].Trim() == "a" ? a : b).Value % 2 == 0)
+                    if ((registerOrOffset!.Split(',')[0].Trim() is "a" ? a : b).Value % 2 == 0)
                     {
                         next = i + Parse<int>(offset!);
                     }
@@ -78,7 +78,7 @@ public sealed class Day23 : Puzzle
                     break;
 
                 case "jio":
-                    if ((registerOrOffset!.Split(',')[0].Trim() == "a" ? a : b).Value == 1)
+                    if ((registerOrOffset!.Split(',')[0].Trim() is "a" ? a : b).Value == 1)
                     {
                         next = i + Parse<int>(offset!);
                     }

--- a/src/AdventOfCode/Puzzles/Y2015/Day25.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day25.cs
@@ -30,7 +30,7 @@ public sealed class Day25 : Puzzle
 
         ulong result = 2015_11_25;
 
-        var current = new Point(0, 0);
+        var current = Point.Empty;
         var target = new Point(column, row);
 
         int currentRow = 0;

--- a/src/AdventOfCode/Puzzles/Y2016/Day01.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day01.cs
@@ -126,7 +126,7 @@ public sealed class Day01 : Puzzle
 
             result[i] = new Instruction()
             {
-                Direction = rawInstruction[0] == 'L' ? Direction.Left : Direction.Right,
+                Direction = rawInstruction[0] is 'L' ? Direction.Left : Direction.Right,
                 Distance = Parse<int>(rawInstruction[1..]),
             };
         }
@@ -146,10 +146,10 @@ public sealed class Day01 : Puzzle
     {
         return bearing switch
         {
-            CardinalDirection.East => direction == Direction.Left ? CardinalDirection.North : CardinalDirection.South,
-            CardinalDirection.North => direction == Direction.Left ? CardinalDirection.West : CardinalDirection.East,
-            CardinalDirection.South => direction == Direction.Left ? CardinalDirection.East : CardinalDirection.West,
-            CardinalDirection.West => direction == Direction.Left ? CardinalDirection.South : CardinalDirection.North,
+            CardinalDirection.East => direction is Direction.Left ? CardinalDirection.North : CardinalDirection.South,
+            CardinalDirection.North => direction is Direction.Left ? CardinalDirection.West : CardinalDirection.East,
+            CardinalDirection.South => direction is Direction.Left ? CardinalDirection.East : CardinalDirection.West,
+            CardinalDirection.West => direction is Direction.Left ? CardinalDirection.South : CardinalDirection.North,
             _ => throw new PuzzleException($"Invalid bearing '{bearing}'."),
         };
     }

--- a/src/AdventOfCode/Puzzles/Y2016/Day02.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day02.cs
@@ -89,7 +89,7 @@ public sealed class Day02 : Puzzle
         {
             for (int x = 0; x < width; x++)
             {
-                if (grid[y, x] == '5')
+                if (grid[y, x] is '5')
                 {
                     origin = new(x, y);
                     break;

--- a/src/AdventOfCode/Puzzles/Y2016/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day04.cs
@@ -120,7 +120,7 @@ public sealed class Day04 : Puzzle
 
         foreach (char ch in encryptedName)
         {
-            if (ch == '-')
+            if (ch is '-')
             {
                 builder.Append(' ');
             }

--- a/src/AdventOfCode/Puzzles/Y2016/Day07.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day07.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using System.Buffers;
-
 namespace MartinCostello.AdventOfCode.Puzzles.Y2016;
 
 /// <summary>
@@ -136,22 +134,10 @@ public sealed class Day07 : Puzzle
             char ch2 = value[i + 1];
             char ch3 = value[i + 2];
 
-            char[] shared = ArrayPool<char>.Shared.Rent(3);
-
-            try
+            if (ch1 != ch2 && ch1 == ch3)
             {
-                shared[0] = ch1;
-                shared[1] = ch2;
-                shared[2] = ch3;
-
-                if (ch1 != ch2 && ch1 == ch3)
-                {
-                    result.Add(new(shared.AsSpan(0, 3)));
-                }
-            }
-            finally
-            {
-                ArrayPool<char>.Shared.Return(shared);
+                Span<char> span = [ch1, ch2, ch3];
+                result.Add(span.ToString());
             }
         }
 

--- a/src/AdventOfCode/Puzzles/Y2016/Day09.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day09.cs
@@ -75,7 +75,7 @@ public sealed class Day09 : Puzzle
 
             if (isInMarker)
             {
-                if (ch == ')')
+                if (ch is ')')
                 {
                     isInMarker = false;
 
@@ -89,7 +89,7 @@ public sealed class Day09 : Puzzle
                     marker.Append(ch);
                 }
             }
-            else if (ch == '(' && !isInRepeat)
+            else if (ch is '(' && !isInRepeat)
             {
                 isInMarker = true;
             }

--- a/src/AdventOfCode/Puzzles/Y2016/Day10.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day10.cs
@@ -31,7 +31,7 @@ public sealed class Day10 : Puzzle
     /// with the values specified by <paramref name="a"/> and <paramref name="b"/> and the product
     /// of the values of the microchips in the output bins with the numbers specified by <paramref name="binsOfInterest"/>.
     /// </returns>
-    internal static (int Bot, int Product) GetBotNumber(ICollection<string> instructions, int a, int b, IEnumerable<int> binsOfInterest)
+    internal static (int Bot, int Product) GetBotNumber(List<string> instructions, int a, int b, IEnumerable<int> binsOfInterest)
     {
         int max = Math.Max(a, b);
         int min = Math.Min(a, b);
@@ -227,7 +227,7 @@ public sealed class Day10 : Puzzle
         /// </summary>
         /// <param name="instructions">The instructions to process.</param>
         /// <param name="onCompare">A delegate to a method to invoke when to microchips are compared by a bot.</param>
-        internal void Process(ICollection<string> instructions, Action<int, int, int> onCompare)
+        internal void Process(List<string> instructions, Action<int, int, int> onCompare)
         {
             OnCompare = onCompare;
 

--- a/src/AdventOfCode/Puzzles/Y2016/Day11.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day11.cs
@@ -227,7 +227,7 @@ public sealed class Day11 : Puzzle
         {
             State = initialState;
 
-            AssemblyFloor = State.Max((p) => p.Key);
+            AssemblyFloor = State.Keys.Max();
             TotalItems = State.SelectMany((p) => p.Value).Count();
 
             Elevator = new Elevator(AssemblyFloor);

--- a/src/AdventOfCode/Puzzles/Y2016/Day15.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day15.cs
@@ -41,7 +41,7 @@ public sealed class Day15 : Puzzle
 
         for (int t = 0; ; t++)
         {
-            bool areAllDiscsAligned = discs.All((p) => p.GetPosition(t + p.Offset) == 0);
+            bool areAllDiscsAligned = discs.All((p) => p.GetPosition(t + p.Offset) is 0);
 
             if (areAllDiscsAligned)
             {

--- a/src/AdventOfCode/Puzzles/Y2016/Day18.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day18.cs
@@ -39,7 +39,7 @@ public sealed class Day18 : Puzzle
 
         for (int x = 0; x < width; x++)
         {
-            if (firstRowTiles[x] == '^')
+            if (firstRowTiles[x] is '^')
             {
                 tiles[x, 0] = true;
             }

--- a/src/AdventOfCode/Puzzles/Y2016/Day21.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day21.cs
@@ -26,21 +26,21 @@ public sealed class Day21 : Puzzle
     /// The scrambled text after applying the instructions in <paramref name="instructions"/>
     /// to the text specified by <paramref name="text"/>.
     /// </returns>
-    internal static string Scramble(string text, IEnumerable<string> instructions, bool reverse)
+    internal static string Scramble(ReadOnlySpan<char> text, IEnumerable<string> instructions, bool reverse)
     {
         if (reverse)
         {
             instructions = instructions.Reverse();
         }
 
-        Span<char> values = text.ToCharArray();
+        Span<char> values = [.. text];
 
         foreach (string instruction in instructions)
         {
             Process(instruction, values, reverse);
         }
 
-        return new string(values);
+        return values.ToString();
     }
 
     /// <summary>
@@ -183,13 +183,14 @@ public sealed class Day21 : Puzzle
             (x, y) = (y, x);
         }
 
-        string value = new(values);
-        string ch = values[x].ToString(CultureInfo.InvariantCulture);
+        List<char> swap = [.. values];
 
-        value = value.Remove(x, 1);
-        value = value.Insert(y, ch);
+        char ch = values[x];
 
-        value.CopyTo(values);
+        swap.RemoveAt(x);
+        swap.Insert(y, ch);
+
+        swap.CopyTo(values);
     }
 
     /// <summary>

--- a/src/AdventOfCode/Puzzles/Y2016/Day24.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day24.cs
@@ -128,15 +128,15 @@ public sealed class Day24 : Puzzle
             {
                 char content = layout[y][x];
 
-                if (content == '#')
+                if (content is '#')
                 {
                     maze.Borders.Add(new(x, y));
                 }
-                else if (content == '0')
+                else if (content is '0')
                 {
                     origin = new(x, y);
                 }
-                else if (content != '.')
+                else if (content is not '.')
                 {
                     waypoints.Add(new(x, y));
                 }

--- a/src/AdventOfCode/Puzzles/Y2017/Day02.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day02.cs
@@ -119,13 +119,13 @@ public sealed class Day02 : Puzzle
     /// <returns>
     /// An array containing the columns for each row of the spreadsheet.
     /// </returns>
-    private static IList<int>[] ParseSpreadsheet(List<string> rows)
+    private static List<int>[] ParseSpreadsheet(List<string> rows)
     {
-        var spreadsheet = new IList<int>[rows.Count];
+        var spreadsheet = new List<int>[rows.Count];
 
         for (int i = 0; i < spreadsheet.Length; i++)
         {
-            spreadsheet[i] = rows[i].AsNumbers<int>('\t').ToArray();
+            spreadsheet[i] = rows[i].AsNumbers<int>('\t');
         }
 
         return spreadsheet;

--- a/src/AdventOfCode/Puzzles/Y2017/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day04.cs
@@ -39,7 +39,7 @@ public sealed class Day04 : Puzzle
                 {
                     Span<char> span = p.ToCharArray();
                     span.Sort();
-                    return new string(span);
+                    return span.ToString();
                 })
                 .ToArray();
 

--- a/src/AdventOfCode/Puzzles/Y2017/Day06.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day06.cs
@@ -40,9 +40,7 @@ public sealed class Day06 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<int> memory = (await ReadResourceAsStringAsync(cancellationToken)).Trim()
-            .AsNumbers<int>('\t')
-            .ToList();
+        var memory = (await ReadResourceAsStringAsync(cancellationToken)).Trim().AsNumbers<int>('\t');
 
         (CycleCount, LoopSize) = Debug(memory);
 

--- a/src/AdventOfCode/Puzzles/Y2017/Day08.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day08.cs
@@ -115,7 +115,7 @@ public sealed class Day08 : Puzzle
     /// <returns>
     /// The result of evaluating the logic condition.
     /// </returns>
-    private static bool Evaluate(int left, int right, string operation)
+    private static bool Evaluate(int left, int right, ReadOnlySpan<char> operation)
     {
         return operation switch
         {

--- a/src/AdventOfCode/Puzzles/Y2017/Day10.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day10.cs
@@ -84,9 +84,7 @@ public sealed class Day10 : Puzzle
     {
         string rawLengths = (await ReadResourceAsStringAsync(cancellationToken)).Trim();
 
-        var lengths = rawLengths
-            .AsNumbers<int>()
-            .ToList();
+        var lengths = rawLengths.AsNumbers<int>();
 
         ProductOfFirstTwoElements = FindProductOfFirstTwoHashElements(SequenceLength, lengths);
         DenseHash = ComputeHash(rawLengths);

--- a/src/AdventOfCode/Puzzles/Y2017/Day11.cs
+++ b/src/AdventOfCode/Puzzles/Y2017/Day11.cs
@@ -153,9 +153,9 @@ public sealed class Day11 : Puzzle
 
         int i = 0;
 
-        foreach (var direction in path.Tokenize(','))
+        foreach (var range in path.Split(','))
         {
-            result[i++] = new string(direction) switch
+            result[i++] = path[range] switch
             {
                 "n" => CardinalDirection.North,
                 "ne" => CardinalDirection.NorthEast,
@@ -163,7 +163,7 @@ public sealed class Day11 : Puzzle
                 "s" => CardinalDirection.South,
                 "se" => CardinalDirection.SouthEast,
                 "sw" => CardinalDirection.SouthWest,
-                _ => throw new PuzzleException($"Unknown direction '{direction}'."),
+                _ => throw new PuzzleException($"Unknown direction '{range}'."),
             };
         }
 

--- a/src/AdventOfCode/Puzzles/Y2018/Day02.cs
+++ b/src/AdventOfCode/Puzzles/Y2018/Day02.cs
@@ -58,8 +58,8 @@ public sealed class Day02 : Puzzle
             counts[ch]++;
         }
 
-        bool hasDoubles = counts.Values.Any((p) => p == 2);
-        bool hasTriples = counts.Values.Any((p) => p == 3);
+        bool hasDoubles = counts.Values.Any((p) => p is 2);
+        bool hasTriples = counts.Values.Any((p) => p is 3);
 
         return (hasDoubles ? 1 : 0, hasTriples ? 1 : 0);
     }

--- a/src/AdventOfCode/Puzzles/Y2018/Day07.cs
+++ b/src/AdventOfCode/Puzzles/Y2018/Day07.cs
@@ -37,10 +37,11 @@ public sealed class Day07 : Puzzle
         var available = new HashSet<string>(instructions.Count * 2);
         var constraints = new Dictionary<string, HashSet<string>>();
 
-        foreach (string instruction in instructions)
+        foreach (string item in instructions)
         {
-            string constraint = instruction["Step ".Length..];
-            string antecedent = constraint[..1];
+            var instruction = item.AsSpan();
+            string constraint = instruction["Step ".Length..].ToString();
+            string antecedent = constraint[..1].ToString();
 
             constraint = constraint[(" must be finished before step ".Length + 1)..];
 

--- a/src/AdventOfCode/Puzzles/Y2018/Day07.cs
+++ b/src/AdventOfCode/Puzzles/Y2018/Day07.cs
@@ -40,12 +40,12 @@ public sealed class Day07 : Puzzle
         foreach (string item in instructions)
         {
             var instruction = item.AsSpan();
-            string constraint = instruction["Step ".Length..].ToString();
+            var constraint = instruction["Step ".Length..];
             string antecedent = constraint[..1].ToString();
 
             constraint = constraint[(" must be finished before step ".Length + 1)..];
 
-            string part = constraint[..1];
+            string part = constraint[..1].ToString();
 
             constraints.GetOrAdd(part).Add(antecedent);
 

--- a/src/AdventOfCode/Puzzles/Y2019/IntcodeVM.cs
+++ b/src/AdventOfCode/Puzzles/Y2019/IntcodeVM.cs
@@ -71,9 +71,9 @@ internal sealed class IntcodeVM
 
         int i = 0;
 
-        foreach (var instruction in program.Tokenize(','))
+        foreach (var range in program.Split(','))
         {
-            instructions[i++] = Puzzle.Parse<long>(instruction);
+            instructions[i++] = Puzzle.Parse<long>(program[range]);
         }
 
         return instructions;
@@ -249,7 +249,7 @@ internal sealed class IntcodeVM
         {
             if (instruction == 99)
             {
-                return (99, Array.Empty<int>(), 1);
+                return (99, [], 1);
             }
 
             string digits = instruction.ToString(CultureInfo.InvariantCulture);

--- a/src/AdventOfCode/Puzzles/Y2020/Day03.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day03.cs
@@ -42,7 +42,7 @@ public sealed class Day03 : Puzzle
 
             for (int j = 0; j < width; j++)
             {
-                if (row[j] == '#')
+                if (row[j] is '#')
                 {
                     space[i, j] = true;
                 }

--- a/src/AdventOfCode/Puzzles/Y2020/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day04.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using System.Collections.Specialized;
 using System.Text.RegularExpressions;
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2020;
@@ -39,21 +38,23 @@ public sealed partial class Day04 : Puzzle
     /// </returns>
     public static (int Valid, int Verified) VerifyPassports(ICollection<string> batch)
     {
-        var passports = new List<NameValueCollection>();
-        var current = new NameValueCollection();
+        var passports = new List<Dictionary<string, string>>();
+        var current = new Dictionary<string, string>();
 
-        foreach (string line in batch)
+        foreach (string item in batch)
         {
-            if (string.IsNullOrEmpty(line))
+            var line = item.AsSpan();
+
+            if (line.IsEmpty)
             {
                 passports.Add(current);
                 current = [];
                 continue;
             }
 
-            foreach (var pair in line.Tokenize(' '))
+            foreach (var range in line.Split(' '))
             {
-                pair.Bifurcate(':', out var name, out var value);
+                line[range].Bifurcate(':', out var name, out var value);
                 current[new string(name)] = new(value);
             }
         }
@@ -68,7 +69,7 @@ public sealed partial class Day04 : Puzzle
 
         foreach (var passport in passports)
         {
-            bool isValid = passport.AllKeys.Intersect(RequiredKeys).ExactCount(RequiredKeys.Length);
+            bool isValid = passport.Keys.Intersect(RequiredKeys).ExactCount(RequiredKeys.Length);
 
             if (isValid)
             {
@@ -107,9 +108,9 @@ public sealed partial class Day04 : Puzzle
     /// <returns>
     /// <see langword="true"/> if the passport is verified; otherwise <see langword="false"/>.
     /// </returns>
-    private static bool IsPasswordVerified(NameValueCollection passport)
+    private static bool IsPasswordVerified(Dictionary<string, string> passport)
     {
-        static bool IsValidEyeColor(string? value) => value switch
+        static bool IsValidEyeColor(ReadOnlySpan<char> value) => value switch
         {
             "amb" => true,
             "blu" => true,
@@ -121,9 +122,9 @@ public sealed partial class Day04 : Puzzle
             _ => false,
         };
 
-        static bool IsValidHairColor(string? value)
+        static bool IsValidHairColor(ReadOnlySpan<char> value)
         {
-            if (string.IsNullOrEmpty(value))
+            if (value.IsEmpty)
             {
                 return false;
             }
@@ -163,9 +164,9 @@ public sealed partial class Day04 : Puzzle
         static bool IsValidYear(ReadOnlySpan<char> value, int minimum, int maximum)
             => IsValidNumber(value, minimum, maximum) && value!.Length == 4;
 
-        foreach (string? key in passport.AllKeys)
+        foreach (string? key in passport.Keys)
         {
-            string? value = passport[key];
+            ReadOnlySpan<char> value = passport[key];
 
             bool isValid = key switch
             {

--- a/src/AdventOfCode/Puzzles/Y2020/Day08.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day08.cs
@@ -117,7 +117,7 @@ public sealed class Day08 : Puzzle
 
         foreach (ReadOnlySpan<char> operation in program)
         {
-            var op = new string(operation[..3]) switch
+            var op = operation[..3] switch
             {
                 "acc" => Operation.Accumulate,
                 "jmp" => Operation.Jump,

--- a/src/AdventOfCode/Puzzles/Y2020/Day12.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day12.cs
@@ -42,8 +42,9 @@ public sealed class Day12 : Puzzle
         int heading = Headings.East;
         var ship = Point.Empty;
 
-        foreach (string instruction in instructions)
+        foreach (string item in instructions)
         {
+            var instruction = item.AsSpan();
             int units = Parse<int>(instruction[1..]);
 
             switch (instruction[0..1])
@@ -96,8 +97,9 @@ public sealed class Day12 : Puzzle
         var ship = Point.Empty;
         var waypoint = new Point(10, 1);
 
-        foreach (string instruction in instructions)
+        foreach (string item in instructions)
         {
+            var instruction = item.AsSpan();
             int units = Parse<int>(instruction[1..]);
 
             switch (instruction[0..1])

--- a/src/AdventOfCode/Puzzles/Y2020/Day15.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day15.cs
@@ -57,9 +57,7 @@ public sealed class Day15 : Puzzle
     /// <inheritdoc />
     protected override Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<int> startingNumbers = args[0]
-            .AsNumbers<int>()
-            .ToList();
+        var startingNumbers = args[0].AsNumbers<int>();
 
         Number2020 = GetSpokenNumber(startingNumbers, 2020);
         Number30000000 = GetSpokenNumber(startingNumbers, 30000000);

--- a/src/AdventOfCode/Puzzles/Y2020/Day16.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day16.cs
@@ -31,13 +31,14 @@ public sealed class Day16 : Puzzle
         int indexOfFirstTicket = notes.IndexOf("your ticket:") + 1;
         int indexOfSecondTicket = notes.IndexOf("nearby tickets:") + 1;
 
-        var rules = new Dictionary<string, ICollection<Range>>(indexOfFirstTicket - 2);
+        var rules = new Dictionary<string, Range[]>(indexOfFirstTicket - 2);
+        var alternate = rules.GetAlternateLookup();
 
         // Parse the rules
         foreach (string line in notes.Take(indexOfFirstTicket - 2))
         {
-            (string name, string instruction) = line.Bifurcate(':');
-            string[] split = instruction.Split(" or ", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            line.AsSpan().Bifurcate(':', out var name, out var instruction);
+            string[] split = instruction.ToString().Split(" or ", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
             var ranges = new Range[split.Length];
 
@@ -47,25 +48,21 @@ public sealed class Day16 : Puzzle
                 ranges[i] = new(start, end);
             }
 
-            rules[name] = ranges;
+            alternate[name] = ranges;
         }
 
-        var allTickets = new IList<int>[notes.Count - indexOfSecondTicket + 1];
+        var allTickets = new List<int>[notes.Count - indexOfSecondTicket + 1];
 
-        allTickets[0] = notes[indexOfFirstTicket]
-            .AsNumbers<int>()
-            .ToArray();
+        allTickets[0] = notes[indexOfFirstTicket].AsNumbers<int>();
 
         // Parse the nearby tickets
         for (int i = indexOfSecondTicket; i < notes.Count; i++)
         {
-            allTickets[i - indexOfSecondTicket + 1] = notes[i]
-                .AsNumbers<int>()
-                .ToArray();
+            allTickets[i - indexOfSecondTicket + 1] = notes[i].AsNumbers<int>();
         }
 
         int invalidValues = 0;
-        var validTickets = new List<IList<int>>();
+        var validTickets = new List<List<int>>();
 
         // Find the valid tickets
         for (int i = 1; i < allTickets.Length; i++)
@@ -77,7 +74,7 @@ public sealed class Day16 : Puzzle
             {
                 int value = ticket[j];
 
-                foreach (ICollection<Range> ranges in rules.Values)
+                foreach (var ranges in rules.Values)
                 {
                     isValid = ranges.Any((p) => InRange(value, p));
 
@@ -135,7 +132,7 @@ public sealed class Day16 : Puzzle
 
                     for (int j = 0; j < validTickets.Count; j++)
                     {
-                        IList<int> ticket = validTickets[j];
+                        var ticket = validTickets[j];
                         int value = ticket[index];
 
                         bool isInRange = rule.Value.Any((p) => InRange(value, p));

--- a/src/AdventOfCode/Puzzles/Y2020/Day17.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day17.cs
@@ -112,7 +112,7 @@ public sealed class Day17 : Puzzle
                 visualization = WriteState(currentState, logger);
             }
 
-            int activeCubes = currentState.Values.Count((p) => p == Active);
+            int activeCubes = currentState.Values.Count((p) => p is Active);
 
             return (activeCubes, visualization);
 
@@ -126,10 +126,7 @@ public sealed class Day17 : Puzzle
                 {
                     foreach (Vector3 adjacent in AdjacentCubes(point))
                     {
-                        if (!states.ContainsKey(adjacent))
-                        {
-                            states[adjacent] = Inactive;
-                        }
+                        states.TryAdd(adjacent, Inactive);
                     }
                 }
             }
@@ -187,9 +184,9 @@ public sealed class Day17 : Puzzle
         {
             var builder = new StringBuilder();
 
-            float maxY = states.Max((p) => p.Key.Y);
-            float maxX = states.Max((p) => p.Key.X);
-            float maxZ = states.Max((p) => p.Key.Z);
+            float maxY = states.Keys.Max((p) => p.Y);
+            float maxX = states.Keys.Max((p) => p.X);
+            float maxZ = states.Keys.Max((p) => p.Z);
             float minZ = -maxZ;
 
             for (float z = minZ; z <= maxZ; z++)
@@ -344,10 +341,10 @@ public sealed class Day17 : Puzzle
         {
             var builder = new StringBuilder();
 
-            float maxW = states.Max((p) => p.Key.W);
-            float maxY = states.Max((p) => p.Key.Y);
-            float maxX = states.Max((p) => p.Key.X);
-            float maxZ = states.Max((p) => p.Key.Z);
+            float maxW = states.Keys.Max((p) => p.W);
+            float maxY = states.Keys.Max((p) => p.Y);
+            float maxX = states.Keys.Max((p) => p.X);
+            float maxZ = states.Keys.Max((p) => p.Z);
             float minW = -maxW;
             float minZ = -maxZ;
 

--- a/src/AdventOfCode/Puzzles/Y2020/Day18.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day18.cs
@@ -63,11 +63,11 @@ public sealed class Day18 : Puzzle
                     {
                         char thisChar = expression[j];
 
-                        if (thisChar == '(')
+                        if (thisChar is '(')
                         {
                             openCount++;
                         }
-                        else if (thisChar == ')')
+                        else if (thisChar is ')')
                         {
                             closedCount++;
                         }

--- a/src/AdventOfCode/Puzzles/Y2020/Day20.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day20.cs
@@ -560,7 +560,7 @@ public sealed class Day20 : Puzzle
                     rotation[length - y - 1] = Grid[y][x];
                 }
 
-                rotated[x] = new(rotation);
+                rotated[x] = rotation.ToString();
             }
 
             Grid = rotated;

--- a/src/AdventOfCode/Puzzles/Y2020/Day21.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day21.cs
@@ -38,9 +38,9 @@ public sealed class Day21 : Puzzle
 
         for (int i = 0; i < foods.Count; i++)
         {
-            (string first, string second) = foods[i].Bifurcate('(');
-            string[] ingredients = first.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            string[] allergens = second[9..].TrimEnd(')').Split(", ");
+            foods[i].AsSpan().Bifurcate('(', out var first, out var second);
+            string[] ingredients = first.ToString().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            string[] allergens = second[9..].TrimEnd(')').ToString().Split(", ");
 
             parsedFoods[i] = (ingredients, allergens);
         }

--- a/src/AdventOfCode/Puzzles/Y2020/Day23.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day23.cs
@@ -89,7 +89,7 @@ public sealed class Day23 : Puzzle
     /// <inheritdoc />
     protected override Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IEnumerable<int> arrangement = args[0].Select((p) => p - '0').ToArray();
+        IEnumerable<int> arrangement = args[0].Select((p) => p - '0');
 
         var circle = Play(arrangement, moves: 100);
 

--- a/src/AdventOfCode/Puzzles/Y2020/Day24.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day24.cs
@@ -71,9 +71,9 @@ public sealed class Day24 : Puzzle
         static Dictionary<Tile, bool> Iterate(Dictionary<Tile, bool> floor)
         {
             // See https://www.redblobgames.com/grids/hexagons/#range
-            int maximumX = floor.Max((p) => Math.Abs(p.Key.X));
-            int maximumY = floor.Max((p) => Math.Abs(p.Key.Y));
-            int maximumZ = floor.Max((p) => Math.Abs(p.Key.Z));
+            int maximumX = floor.Keys.Max((p) => Math.Abs(p.X));
+            int maximumY = floor.Keys.Max((p) => Math.Abs(p.Y));
+            int maximumZ = floor.Keys.Max((p) => Math.Abs(p.Z));
 
             int n = Math.Max(maximumX, maximumY);
             n = Math.Max(n, maximumZ) + 1;

--- a/src/AdventOfCode/Puzzles/Y2021/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day04.cs
@@ -28,10 +28,7 @@ public sealed class Day04 : Puzzle
     /// </returns>
     public static (int FirstWinningScore, int LastWinningScore) PlayBingo(IEnumerable<string> game)
     {
-        int[] numbers = game
-            .First()
-            .AsNumbers<int>()
-            .ToArray();
+        var numbers = game.First().AsNumbers<int>();
 
         var cards = ParseCards(game);
 
@@ -112,11 +109,9 @@ public sealed class Day04 : Puzzle
             {
                 string line = card[i];
 
-                int[] numbers = line
-                    .AsNumbers<int>(' ', StringSplitOptions.RemoveEmptyEntries)
-                    .ToArray();
+                var numbers = line.AsNumbers<int>(' ', StringSplitOptions.RemoveEmptyEntries);
 
-                for (int j = 0; j < numbers.Length; j++)
+                for (int j = 0; j < numbers.Count; j++)
                 {
                     squares[i, j] = new() { Number = numbers[j] };
                 }

--- a/src/AdventOfCode/Puzzles/Y2021/Day06.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day06.cs
@@ -79,7 +79,7 @@ public sealed class Day06 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<int> fish = (await ReadResourceAsStringAsync(cancellationToken)).AsNumbers<int>().ToArray();
+        var fish = (await ReadResourceAsStringAsync(cancellationToken)).AsNumbers<int>();
 
         FishCount80 = CountFish(fish, days: 80);
         FishCount256 = CountFish(fish, days: 256);

--- a/src/AdventOfCode/Puzzles/Y2021/Day07.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day07.cs
@@ -72,7 +72,7 @@ public sealed class Day07 : Puzzle
     /// <inheritdoc />
     protected override async Task<PuzzleResult> SolveCoreAsync(string[] args, CancellationToken cancellationToken)
     {
-        IList<int> submarines = (await ReadResourceAsStringAsync(cancellationToken)).AsNumbers<int>().ToArray();
+        var submarines = (await ReadResourceAsStringAsync(cancellationToken)).AsNumbers<int>();
 
         FuelConsumedWithConstantBurnRate = AlignSubmarines(submarines, withVariableBurnRate: false);
         FuelConsumedWithVariableBurnRate = AlignSubmarines(submarines, withVariableBurnRate: true);

--- a/src/AdventOfCode/Puzzles/Y2021/Day08.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day08.cs
@@ -34,11 +34,8 @@ public sealed class Day08 : Puzzle
 
         for (int i = 0; i < entries.Count; i++)
         {
-            string[] parts = entries[i].Split(" | ");
-            string[] signals = parts[0].Split(' ');
-            string[] numbers = parts[1].Split(' ');
-
-            panels[i] = (signals, numbers);
+            (string signals, string numbers) = entries[i].Bifurcate(" | ");
+            panels[i] = (signals.Split(' '), numbers.Split(' '));
         }
 
         int count = 0;

--- a/src/AdventOfCode/Puzzles/Y2021/Day13.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day13.cs
@@ -45,13 +45,13 @@ public sealed class Day13 : Puzzle
                 continue;
             }
 
-            if (instruction[0] == 'f')
+            if (instruction[0] is 'f')
             {
                 string fold = instruction.Split(' ')[2];
                 string[] parts = fold.Split('=');
                 int size = Parse<int>(parts[1]);
 
-                if (parts[0][0] == 'x')
+                if (parts[0][0] is 'x')
                 {
                     foldLines.Add(new(size, 0));
                 }
@@ -63,7 +63,7 @@ public sealed class Day13 : Puzzle
                 continue;
             }
 
-            int[] points = instruction.AsNumbers<int>().ToArray();
+            var points = instruction.AsNumbers<int>();
 
             paper[new(points[0], points[1])] = true;
         }

--- a/src/AdventOfCode/Puzzles/Y2021/Day14.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day14.cs
@@ -36,14 +36,12 @@ public sealed class Day14 : Puzzle
         string template = instructions[0];
 
         var insertions = new Dictionary<string, char>(instructions.Count - 2);
+        var alternate = insertions.GetAlternateLookup();
 
         foreach (string instruction in instructions.Skip(2))
         {
-            string[] split = instruction.Split(" -> ");
-            string pair = split[0];
-            char element = split[1][0];
-
-            insertions[pair] = element;
+            instruction.AsSpan().Bifurcate(" -> ", out var pair, out var element);
+            alternate[pair] = element[0];
         }
 
         var pairCounts = new Dictionary<string, long>();
@@ -66,8 +64,8 @@ public sealed class Day14 : Puzzle
                 {
                     pairCounts[pair] -= count;
 
-                    string pair1 = pair[0] + string.Empty + element;
-                    string pair2 = element + string.Empty + pair[1];
+                    string pair1 = $"{pair[0]}{element}";
+                    string pair2 = $"{element}{pair[1]}";
 
                     pairCounts.AddOrIncrement(pair1, count, count);
                     pairCounts.AddOrIncrement(pair2, count, count);

--- a/src/AdventOfCode/Puzzles/Y2021/Day17.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day17.cs
@@ -50,22 +50,14 @@ public sealed class Day17 : Puzzle
 
         return (apogees.Max(), apogees.Count);
 
-        static Rectangle GetTargetArea(string target)
+        static Rectangle GetTargetArea(ReadOnlySpan<char> target)
         {
             target = target["target area: ".Length..];
 
-            string[] split = target.Split(',', StringSplitOptions.TrimEntries);
-            string rangeX = split[0][2..];
-            string rangeY = split[1][2..];
+            target.Bifurcate(',', out var rangeX, out var rangeY);
 
-            string[] valuesX = rangeX.Split("..");
-            string[] valuesY = rangeY.Split("..");
-
-            int minX = Parse<int>(valuesX[0]);
-            int maxX = Parse<int>(valuesX[1]);
-
-            int minY = Parse<int>(valuesY[0]);
-            int maxY = Parse<int>(valuesY[1]);
+            (int minX, int maxX) = rangeX.Trim()[2..].AsNumberPair<int>("..");
+            (int minY, int maxY) = rangeY.Trim()[2..].AsNumberPair<int>("..");
 
             return new(
                 minX,

--- a/src/AdventOfCode/Puzzles/Y2021/Day19.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day19.cs
@@ -112,7 +112,7 @@ public sealed class Day19 : Puzzle
                     continue;
                 }
 
-                int[] values = value.AsNumbers<int>().ToArray();
+                var values = value.AsNumbers<int>();
 
                 current.Add(new(values[0], values[1], values[2]));
             }

--- a/src/AdventOfCode/Puzzles/Y2021/Day22.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day22.cs
@@ -107,22 +107,13 @@ public sealed class Day22 : Puzzle
 
         static (Cuboid Cuboid, bool TurnOn) Parse(string instruction)
         {
-            (string state, string coordinates) = instruction.Bifurcate(' ');
-            (string rangeX, string rangeY, string rangeZ) = coordinates.Trifurcate(',');
+            instruction.AsSpan().Bifurcate(' ', out var state, out var coordinates);
+            coordinates.Trifurcate(',', out var rangeX, out var rangeY, out var rangeZ);
 
             const string Range = "..";
-            string[] valuesX = rangeX[2..].Split(Range);
-            string[] valuesY = rangeY[2..].Split(Range);
-            string[] valuesZ = rangeZ[2..].Split(Range);
-
-            int minX = Parse<int>(valuesX[0]);
-            int maxX = Parse<int>(valuesX[1]);
-
-            int minY = Parse<int>(valuesY[0]);
-            int maxY = Parse<int>(valuesY[1]);
-
-            int minZ = Parse<int>(valuesZ[0]);
-            int maxZ = Parse<int>(valuesZ[1]);
+            (int minX, int maxX) = rangeX[2..].AsNumberPair<int>(Range);
+            (int minY, int maxY) = rangeY[2..].AsNumberPair<int>(Range);
+            (int minZ, int maxZ) = rangeZ[2..].AsNumberPair<int>(Range);
 
             int lengthX = maxX - minX + 1;
             int lengthY = maxY - minY + 1;

--- a/src/AdventOfCode/Puzzles/Y2021/Day24.cs
+++ b/src/AdventOfCode/Puzzles/Y2021/Day24.cs
@@ -39,8 +39,8 @@ public sealed class Day24 : Puzzle
         {
             int section = i * Sections;
 
-            int a = Parse<int>(instructions[section + 5][6..]);
-            int b = Parse<int>(instructions[section + 15][6..]);
+            int a = Parse<int>(instructions[section + 5].AsSpan()[6..]);
+            int b = Parse<int>(instructions[section + 15].AsSpan()[6..]);
 
             constants[i] = (a, b);
         }

--- a/src/AdventOfCode/Puzzles/Y2022/Day02.cs
+++ b/src/AdventOfCode/Puzzles/Y2022/Day02.cs
@@ -45,14 +45,14 @@ public sealed class Day02 : Puzzle
     {
         int total = 0;
 
-        Func<ReadOnlySpan<char>, Move, Move> moveSelector =
+        Func<string, Move, Move> moveSelector =
             containsDesiredOutcome ?
             (value, opponent) => GetMove(ParseOutcome(value), opponent) :
             (value, _) => ParseMove(value);
 
         foreach (string move in moves)
         {
-            move.AsSpan().AsPair(' ', out var opponent, out var player);
+            (string opponent, string player) = move.AsPair(' ');
 
             Move opponentMove = ParseMove(opponent);
             Move playerMove = moveSelector(player, opponentMove);
@@ -87,20 +87,20 @@ public sealed class Day02 : Puzzle
             _ => player == opponent ? Outcome.Draw : throw new InvalidOperationException("Invalid move combination."),
         };
 
-        static Move ParseMove(ReadOnlySpan<char> value) => value switch
+        static Move ParseMove(string value) => value switch
         {
             "A" or "X" => Move.Rock,
             "B" or "Y" => Move.Paper,
             "C" or "Z" => Move.Scissors,
-            _ => throw new ArgumentOutOfRangeException(nameof(value), value.ToString(), "Invalid move."),
+            _ => throw new ArgumentOutOfRangeException(nameof(value), value, "Invalid move."),
         };
 
-        static Outcome ParseOutcome(ReadOnlySpan<char> value) => value switch
+        static Outcome ParseOutcome(string value) => value switch
         {
             "X" => Outcome.Lose,
             "Y" => Outcome.Draw,
             "Z" => Outcome.Win,
-            _ => throw new ArgumentOutOfRangeException(nameof(value), value.ToString(), "Invalid outcome."),
+            _ => throw new ArgumentOutOfRangeException(nameof(value), value, "Invalid outcome."),
         };
     }
 

--- a/src/AdventOfCode/Puzzles/Y2022/Day02.cs
+++ b/src/AdventOfCode/Puzzles/Y2022/Day02.cs
@@ -52,7 +52,7 @@ public sealed class Day02 : Puzzle
 
         foreach (string move in moves)
         {
-            (string opponent, string player) = move.AsPair(' ');
+            (string opponent, string player) = move.AsSpan().AsPair(' ');
 
             Move opponentMove = ParseMove(opponent);
             Move playerMove = moveSelector(player, opponentMove);

--- a/src/AdventOfCode/Puzzles/Y2022/Day02.cs
+++ b/src/AdventOfCode/Puzzles/Y2022/Day02.cs
@@ -45,14 +45,14 @@ public sealed class Day02 : Puzzle
     {
         int total = 0;
 
-        Func<string, Move, Move> moveSelector =
+        Func<ReadOnlySpan<char>, Move, Move> moveSelector =
             containsDesiredOutcome ?
             (value, opponent) => GetMove(ParseOutcome(value), opponent) :
             (value, _) => ParseMove(value);
 
         foreach (string move in moves)
         {
-            (string opponent, string player) = move.AsPair(' ');
+            move.AsSpan().AsPair(' ', out var opponent, out var player);
 
             Move opponentMove = ParseMove(opponent);
             Move playerMove = moveSelector(player, opponentMove);
@@ -87,20 +87,20 @@ public sealed class Day02 : Puzzle
             _ => player == opponent ? Outcome.Draw : throw new InvalidOperationException("Invalid move combination."),
         };
 
-        static Move ParseMove(string value) => value switch
+        static Move ParseMove(ReadOnlySpan<char> value) => value switch
         {
             "A" or "X" => Move.Rock,
             "B" or "Y" => Move.Paper,
             "C" or "Z" => Move.Scissors,
-            _ => throw new ArgumentOutOfRangeException(nameof(value), value, "Invalid move."),
+            _ => throw new ArgumentOutOfRangeException(nameof(value), value.ToString(), "Invalid move."),
         };
 
-        static Outcome ParseOutcome(string value) => value switch
+        static Outcome ParseOutcome(ReadOnlySpan<char> value) => value switch
         {
             "X" => Outcome.Lose,
             "Y" => Outcome.Draw,
             "Z" => Outcome.Win,
-            _ => throw new ArgumentOutOfRangeException(nameof(value), value, "Invalid outcome."),
+            _ => throw new ArgumentOutOfRangeException(nameof(value), value.ToString(), "Invalid outcome."),
         };
     }
 

--- a/src/AdventOfCode/Puzzles/Y2022/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2022/Day04.cs
@@ -33,10 +33,9 @@ public sealed class Day04 : Puzzle
 
         foreach (string assignment in assignments)
         {
-            assignment.AsSpan().Bifurcate(',', out var firstSpan, out var secondSpan);
-
-            Range first = AsRange(firstSpan.AsNumberPair<int>('-'));
-            Range second = AsRange(secondSpan.AsNumberPair<int>('-'));
+            string[] split = assignment.Split(',');
+            Range first = AsRange(split[0].AsNumberPair<int>('-'));
+            Range second = AsRange(split[1].AsNumberPair<int>('-'));
 
             if (partial)
             {

--- a/src/AdventOfCode/Puzzles/Y2022/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2022/Day04.cs
@@ -33,9 +33,10 @@ public sealed class Day04 : Puzzle
 
         foreach (string assignment in assignments)
         {
-            string[] split = assignment.Split(',');
-            Range first = AsRange(split[0].AsNumberPair<int>('-'));
-            Range second = AsRange(split[1].AsNumberPair<int>('-'));
+            assignment.AsSpan().Bifurcate(',', out var firstSpan, out var secondSpan);
+
+            Range first = AsRange(firstSpan.AsNumberPair<int>('-'));
+            Range second = AsRange(secondSpan.AsNumberPair<int>('-'));
 
             if (partial)
             {

--- a/src/AdventOfCode/Puzzles/Y2022/Day07.cs
+++ b/src/AdventOfCode/Puzzles/Y2022/Day07.cs
@@ -12,7 +12,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2022;
 public sealed class Day07 : Puzzle
 {
     /// <summary>
-    /// Gets the total size of all directories with a total size of at least 100000.
+    /// Gets the total size of all directories with a total size of at least 100,000.
     /// </summary>
     public long TotalSizeOfDirectoriesLargerThanLimit { get; private set; }
 
@@ -22,12 +22,12 @@ public sealed class Day07 : Puzzle
     public long SizeOfSmallestDirectoryToDelete { get; private set; }
 
     /// <summary>
-    /// Finds the total size of the directories with a total size of at least 100000 and
+    /// Finds the total size of the directories with a total size of at least 100,000 and
     /// the total size of the smallest directory to delete that frees enough disk space.
     /// </summary>
     /// <param name="terminalOutput">The terminal output to parse.</param>
     /// <returns>
-    /// The total size of all directories with a total size of at least 100000 and
+    /// The total size of all directories with a total size of at least 100,000 and
     /// the total size of the smallest directory to delete that frees enough disk space.
     /// </returns>
     public static (long TotalSizeOfDirectoriesLargerThanLimit, long SizeOfSmallestDirectoryToDelete) GetDirectorySizes(
@@ -125,7 +125,7 @@ public sealed class Day07 : Puzzle
                 }
                 else
                 {
-                    (string first, string second) = item.AsPair(' ');
+                    (string first, string second) = item.AsSpan().AsPair(' ');
                     current.Children.Add(new File(second, current, Parse<long>(first)));
                 }
             }

--- a/src/AdventOfCode/Puzzles/Y2022/Day10.cs
+++ b/src/AdventOfCode/Puzzles/Y2022/Day10.cs
@@ -43,7 +43,9 @@ public sealed class Day10 : Puzzle
 
         foreach (string instruction in program)
         {
-            switch (instruction[..4])
+            var span = instruction.AsSpan();
+
+            switch (span[..4])
             {
                 case "noop":
                     Tick();
@@ -51,7 +53,7 @@ public sealed class Day10 : Puzzle
 
                 case "addx":
                     Tick();
-                    Tick(instruction[5..]);
+                    Tick(span[5..]);
                     break;
 
                 default:
@@ -59,11 +61,11 @@ public sealed class Day10 : Puzzle
             }
         }
 
-        void Tick(string? operand = null)
+        void Tick(ReadOnlySpan<char> operand = default)
         {
             Draw();
 
-            if (operand is { })
+            if (!operand.IsEmpty)
             {
                 register += Parse<int>(operand);
             }

--- a/src/AdventOfCode/Puzzles/Y2022/Day11.cs
+++ b/src/AdventOfCode/Puzzles/Y2022/Day11.cs
@@ -95,7 +95,7 @@ public sealed class Day11 : Puzzle
 
                 if (operation.StartsWith('+'))
                 {
-                    if (operationString == "old")
+                    if (operationString is "old")
                     {
                         monkey.Inspector = static (p) => p + p;
                     }
@@ -107,7 +107,7 @@ public sealed class Day11 : Puzzle
                 }
                 else if (operation.StartsWith('*'))
                 {
-                    if (operationString == "old")
+                    if (operationString is "old")
                     {
                         monkey.Inspector = (p) => p * p;
                     }

--- a/src/AdventOfCode/Puzzles/Y2023/Day02.cs
+++ b/src/AdventOfCode/Puzzles/Y2023/Day02.cs
@@ -49,7 +49,7 @@ public sealed class Day02 : Puzzle
 
                 foreach (string cube in cubes)
                 {
-                    (string count, string color) = cube.TrimStart().Bifurcate(' ');
+                    cube.AsSpan().TrimStart().Bifurcate(' ', out var count, out var color);
                     int number = Parse<int>(count);
 
                     switch (color)

--- a/src/AdventOfCode/Puzzles/Y2023/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2023/Day04.cs
@@ -42,8 +42,28 @@ public sealed class Day04 : Puzzle
 
             scratchcard[(index + 1)..].Bifurcate('|', out var winningNumbers, out var numbersHave);
 
-            HashSet<int> winning = new(new string(winningNumbers).Split(' ', StringSplitOptions.RemoveEmptyEntries).Select(Parse<int>));
-            HashSet<int> have = new(new string(numbersHave).Split(' ', StringSplitOptions.RemoveEmptyEntries).Select(Parse<int>));
+            var winning = new HashSet<int>();
+            var have = new HashSet<int>();
+
+            foreach (var range in winningNumbers.Split(' '))
+            {
+                var number = winningNumbers[range];
+
+                if (!number.IsEmpty)
+                {
+                    winning.Add(Parse<int>(number));
+                }
+            }
+
+            foreach (var range in numbersHave.Split(' '))
+            {
+                var number = numbersHave[range];
+
+                if (!number.IsEmpty)
+                {
+                    have.Add(Parse<int>(number));
+                }
+            }
 
             have.IntersectWith(winning);
 

--- a/src/AdventOfCode/Puzzles/Y2023/Day08.cs
+++ b/src/AdventOfCode/Puzzles/Y2023/Day08.cs
@@ -62,16 +62,19 @@ public sealed class Day08 : Puzzle
         {
             string path = nodes[0];
             var network = new Graph<string>();
+            var alternate = network.Edges.GetAlternateLookup();
 
             foreach (string node in nodes.Skip(2))
             {
-                string location = node[..3];
-                string left = node.Substring(7, 3);
-                string right = node.Substring(12, 3);
+                var span = node.AsSpan();
 
-                var edge = network.Edges.GetOrAdd(location);
-                edge.Add(left);
-                edge.Add(right);
+                var location = span[..3];
+                var left = span.Slice(7, 3);
+                var right = span.Slice(12, 3);
+
+                var edge = alternate.GetOrAdd(location);
+                edge.Add(left.ToString());
+                edge.Add(right.ToString());
             }
 
             return (path, network);

--- a/src/AdventOfCode/Puzzles/Y2023/Day19.cs
+++ b/src/AdventOfCode/Puzzles/Y2023/Day19.cs
@@ -96,6 +96,7 @@ public sealed class Day19 : Puzzle
         static Dictionary<string, Workflow> ParseWorkflows(List<string> values)
         {
             var workflows = new Dictionary<string, Workflow>(values.Count);
+            var alternate = workflows.GetAlternateLookup();
 
             var comparer = Comparer<int>.Default;
             var accept = new Analyzer(static (p) => (null, true));
@@ -137,7 +138,7 @@ public sealed class Day19 : Puzzle
                                 break;
 
                             default:
-                                string next = new(rule);
+                                string next = rule.ToString();
                                 analyzers.Add(new((_) => (next, null)));
                                 break;
                         }
@@ -147,7 +148,7 @@ public sealed class Day19 : Puzzle
                         char category = rule[0];
                         char operation = rule[1];
                         int operand = Parse<int>(rule[2..delimiter]);
-                        string next = new(rule[(delimiter + 1)..]);
+                        string next = rule[(delimiter + 1)..].ToString();
 
                         int sign = operation switch
                         {
@@ -181,7 +182,7 @@ public sealed class Day19 : Puzzle
                     rules = rules[(index + 1)..];
                 }
 
-                workflows[new(name)] = new(analyzers, workflows);
+                alternate[name] = new(analyzers, workflows);
             }
 
             return workflows;

--- a/src/AdventOfCode/RectangleExtensions.cs
+++ b/src/AdventOfCode/RectangleExtensions.cs
@@ -29,14 +29,14 @@ internal static class RectangleExtensions
     {
         for (int x = 0; x < rectangle.Width; x++)
         {
-            yield return new Point(x, 0);
-            yield return new Point(x, rectangle.Height - 1);
+            yield return new(x, 0);
+            yield return new(x, rectangle.Height - 1);
         }
 
         for (int y = 1; y < rectangle.Height - 1; y++)
         {
-            yield return new Point(0, y);
-            yield return new Point(rectangle.Width - 1, y);
+            yield return new(0, y);
+            yield return new(rectangle.Width - 1, y);
         }
     }
 }

--- a/tests/AdventOfCode.Tests/Puzzles/Y2016/Day10Tests.cs
+++ b/tests/AdventOfCode.Tests/Puzzles/Y2016/Day10Tests.cs
@@ -9,7 +9,7 @@ public sealed class Day10Tests(ITestOutputHelper outputHelper) : PuzzleTest(outp
     public static void Y2016_Day10_GetBotNumber_Returns_Correct_Solution()
     {
         // Arrange
-        string[] instructions =
+        List<string> instructions =
         [
             "value 5 goes to bot 2",
             "bot 2 gives low to bot 1 and high to bot 0",


### PR DESCRIPTION
- Various refactoring to make more use of span, including new dictionary alternate lookup to avoid creating strings just to use as dictionary keys.
- Use `is` or `is not` instead of equality for some comparisons.
- Use concrete types instead of interfaces in some places.
- Use `.Keys` rather than selecting and then choosing `Key`.
