### PR TITLE
Add extra NuGet feed for crank

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,6 +7,7 @@ env:
   DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
   NUGET_XMLDOC_MODE: skip
   TERM: xterm
+  RestoreAdditionalProjectSources: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json
 
 on:
   issue_comment:


### PR DESCRIPTION
Add an extra NuGet feed for Crank to use, otherwise it fails to get NuGet packages from CI feeds when using `Latest`.
