### PR TITLE
Remove short job

### DIFF
--- a/crank.yml
+++ b/crank.yml
@@ -11,7 +11,7 @@ jobs:
       project: tests/AdventOfCode.Benchmarks/AdventOfCode.Benchmarks.csproj
     variables:
       filterArg: "*"
-    arguments: --filter {{filterArg}} --memory
+    arguments: --filter {{filterArg}} --job Short --memory
     channel: Current
     options:
       benchmarkDotNet: true

--- a/tests/AdventOfCode.Benchmarks/PuzzleBenchmarks.cs
+++ b/tests/AdventOfCode.Benchmarks/PuzzleBenchmarks.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Caching.Memory;
 namespace MartinCostello.AdventOfCode.Benchmarks;
 
 [MemoryDiagnoser]
-[ShortRunJob]
 public class PuzzleBenchmarks
 {
     public static IEnumerable<object> Puzzles()


### PR DESCRIPTION
Remove `[ShortRunJob]` and explicitly use a short job with crank.
