### PR TITLE
Avoid rate-limiting

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Run Trivy (SARIF)
         uses: aquasecurity/trivy-action@0.28.0
         env:
+          ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TRIVY_USERNAME: ${{ secrets.TRIVY_USERNAME }}
           TRIVY_PASSWORD: ${{ secrets.TRIVY_PASSWORD }}
         with:
@@ -59,6 +60,7 @@ jobs:
       - name: Run Trivy (JSON)
         uses: aquasecurity/trivy-action@0.28.0
         env:
+          ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TRIVY_USERNAME: ${{ secrets.TRIVY_USERNAME }}
           TRIVY_PASSWORD: ${{ secrets.TRIVY_PASSWORD }}
         with:


### PR DESCRIPTION
Avoid rate-limiting when running Trivy scans.
