### PR TITLE
Day 6 refactoring

### DIFF
--- a/src/AdventOfCode/Directions.cs
+++ b/src/AdventOfCode/Directions.cs
@@ -38,38 +38,4 @@ internal static class Directions
         Up,
         Down,
     ];
-
-    /// <summary>
-    /// Returns the direction to the right of the specified direction.
-    /// </summary>
-    /// <param name="direction">The direction.</param>
-    /// <returns>
-    /// The direction after turning right by 90 degrees.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// <paramref name="direction"/> is not a valid direction.
-    /// </exception>
-    public static Size TurnRight(Size direction)
-    {
-        if (direction == Up)
-        {
-            return Right;
-        }
-        else if (direction == Right)
-        {
-            return Down;
-        }
-        else if (direction == Down)
-        {
-            return Left;
-        }
-        else if (direction == Left)
-        {
-            return Up;
-        }
-        else
-        {
-            throw new ArgumentOutOfRangeException(nameof(direction), direction, "Invalid direction.");
-        }
-    }
 }

--- a/src/AdventOfCode/Puzzles/Y2024/Day06.cs
+++ b/src/AdventOfCode/Puzzles/Y2024/Day06.cs
@@ -109,19 +109,15 @@ public sealed class Day06 : Puzzle
     {
         var direction = Directions.Up;
         var location = origin;
-        var route = new HashSet<(Point, Size)>();
+        var route = new HashSet<(Point, Size)>()
+        {
+            (location, direction),
+        };
 
         bool loop = false;
 
         do
         {
-            if (!route.Add((location, direction)))
-            {
-                // The guard has reached a position and orientation previously visited
-                loop = true;
-                break;
-            }
-
             Point next = location + direction;
 
             if (!lab.TryGetValue(next, out bool obstructed))
@@ -138,6 +134,13 @@ public sealed class Day06 : Puzzle
             else
             {
                 location = next;
+
+                if (!route.Add((location, direction)))
+                {
+                    // The guard has reached a position and orientation previously visited
+                    loop = true;
+                    break;
+                }
             }
         }
         while (!cancellationToken.IsCancellationRequested);

--- a/src/AdventOfCode/Puzzles/Y2024/Day06.cs
+++ b/src/AdventOfCode/Puzzles/Y2024/Day06.cs
@@ -133,14 +133,14 @@ public sealed class Day06 : Puzzle
             }
             else
             {
-                location = next;
-
-                if (!route.Add((location, direction)))
+                if (!route.Add((next, direction)))
                 {
                     // The guard has reached a position and orientation previously visited
                     loop = true;
                     break;
                 }
+
+                location = next;
             }
         }
         while (!cancellationToken.IsCancellationRequested);

--- a/src/AdventOfCode/Puzzles/Y2024/Day06.cs
+++ b/src/AdventOfCode/Puzzles/Y2024/Day06.cs
@@ -43,9 +43,7 @@ public sealed class Day06 : Puzzle
 
             lab[obstruction] = true;
 
-            (_, bool loop) = Patrol(lab, origin, cancellationToken);
-
-            if (loop)
+            if (Patrol(lab, origin, cancellationToken) is { Loop: true })
             {
                 loops++;
             }

--- a/src/AdventOfCode/Puzzles/Y2024/Day06.cs
+++ b/src/AdventOfCode/Puzzles/Y2024/Day06.cs
@@ -134,7 +134,8 @@ public sealed class Day06 : Puzzle
 
             if (obstructed)
             {
-                direction = Directions.TurnRight(direction);
+                // Turn right by 90°
+                direction = new(-direction.Height, direction.Width);
             }
             else
             {

--- a/src/AdventOfCode/Puzzles/Y2024/Day06.cs
+++ b/src/AdventOfCode/Puzzles/Y2024/Day06.cs
@@ -33,11 +33,11 @@ public sealed class Day06 : Puzzle
 
         (var route, _) = Patrol(lab, origin, cancellationToken);
 
-        var locations = route.Select((p) => p.Location).ToHashSet();
+        var visited = route.Select((p) => p.Location).ToHashSet();
 
         int loops = 0;
 
-        foreach (var obstruction in locations)
+        foreach (var obstruction in visited)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -51,7 +51,7 @@ public sealed class Day06 : Puzzle
             lab[obstruction] = false;
         }
 
-        return (locations.Count, loops);
+        return (visited.Count, loops);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
- Simplify the computation for turning right.
- Use an expression to check the loop result.
- Rename `locations` to `visited`.
- Do not store intermediate rotations in the HashSet.
- Only re-assign `location` if `next` is a valid move.