### PR TITLE
Fix performance regression

### DIFF
--- a/src/AdventOfCode/PathFinding.cs
+++ b/src/AdventOfCode/PathFinding.cs
@@ -114,10 +114,11 @@ public static class PathFinding
                 break;
             }
 
-            long currentCost = costSoFar[current];
+            long? currentCost = null;
 
             foreach (T next in graph.Neighbors(current))
             {
+                currentCost ??= costSoFar[current];
                 long newCost = currentCost + heuristic(current, next);
 
                 if (!costSoFar.TryGetValue(next, out long otherCost) || newCost < otherCost)


### PR DESCRIPTION
Avoid getting the current cost if there are no neighbours.

Introduced by #2023 and identified by [benchmarks dashboard](https://benchmarks.martincostello.com/#Advent%20of%20Code-MartinCostello.AdventOfCode.Benchmarks.PuzzleBenchmarks.Solve2016(input:%20Y2016-13)).

![image](https://github.com/user-attachments/assets/626c0f28-cfef-4ccd-a197-510c15abbb89)
