### PR TITLE
Update Dockerfiles

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,4 @@
-ARG VARIANT="5.0"
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
+FROM mcr.microsoft.com/devcontainers/dotnet:latest@sha256:bdced679b0d7031b802a4e2ead0b3f339473f30e61a52c2f675069efe2e8f7b2
 
 # Suppress an apt-key warning about standard out not being a terminal. Use in this script is safe.
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,11 @@
 version: 2
 updates:
+- package-ecosystem: "docker"
+  directory: ".devcontainer"
+  schedule:
+    interval: daily
+    time: "05:30"
+    timezone: Europe/London
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
- Pin the devcontainer Dockerfile by SHA.
- Remove redundant Dockerfile code.
- Update Dockerfiles with dependabot.
