### PR TITLE
Improve performance

### DIFF
--- a/src/AdventOfCode/Puzzles/Y2016/Day22.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day22.cs
@@ -81,7 +81,17 @@ public sealed class Day22 : Puzzle
         {
             for (int y = 0; y < height; y++)
             {
-                Node node = nodes.First((p) => p.Location.X == x && p.Location.Y == y);
+                Node? node = null;
+
+                for (int i = 0; i < nodes.Count; i++)
+                {
+                    node = nodes[i];
+
+                    if (node.Location.X == x && node.Location.Y == y)
+                    {
+                        break;
+                    }
+                }
 
                 if (node == goalNode)
                 {
@@ -91,7 +101,7 @@ public sealed class Day22 : Puzzle
                 {
                     grid[x, y] = Empty;
                 }
-                else if (node.Used > minimumSize)
+                else if (node!.Used > minimumSize)
                 {
                     grid[x, y] = Full;
                 }


### PR DESCRIPTION
Improve performance by using a for loop instead of `First()` (https://github.com/dotnet/runtime/issues/117717#issuecomment-3082051357).

If it's an improvement on .NET 9, don't merge until after .NET 10 preview 7 ships so can visually confirm in #2106's benchmarks that the regression has gone.

---

Slight regression on runtime, but improvement in allocations:

<img width="700" height="450" alt="image" src="https://github.com/user-attachments/assets/6c202494-0932-41cb-bdf8-097a36749454" />
