### PR TITLE
Bump AwsLambdaTestServer to 0.10.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ UpgradeLog*.XML
 *.suo
 *.TMP
 *.user
+!.packages/*.nupkg

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.6.0" />
-    <PackageVersion Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.9.0" />
+    <PackageVersion Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.10.0-beta.2233" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.6.0" />
-    <PackageVersion Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.10.0-beta.2233" />
+    <PackageVersion Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.10.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.8" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,9 +2,13 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="lambda-test-server" value="https://f.feedz.io/martincostello/lambda-test-server/nuget/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
+    <packageSource key="lambda-test-server">
+      <package pattern="MartinCostello.Testing.AwsLambdaTestServer" />
+    </packageSource>
     <packageSource key="NuGet">
       <package pattern="*" />
     </packageSource>

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,13 +2,9 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="lambda-test-server" value="https://f.feedz.io/martincostello/lambda-test-server/nuget/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
-    <packageSource key="lambda-test-server">
-      <package pattern="MartinCostello.Testing.AwsLambdaTestServer" />
-    </packageSource>
     <packageSource key="NuGet">
       <package pattern="*" />
     </packageSource>

--- a/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
+++ b/tests/AdventOfCode.Tests/Api/HttpLambdaTestServer.cs
@@ -44,12 +44,11 @@ internal sealed class HttpLambdaTestServer()
     public async ValueTask InitializeAsync()
         => await StartAsync(_cts.Token);
 
-    protected override IServer CreateServer(WebHostBuilder builder)
+    protected override IServer CreateServer(IWebHostBuilder builder)
     {
         _webHost = builder
-            .UseKestrel()
+            .UseKestrel((p) => p.Listen(System.Net.IPAddress.Loopback, 0))
             .ConfigureServices((services) => services.AddLogging((builder) => builder.AddXUnit(this)))
-            .UseUrls("http://127.0.0.1:0")
             .Build();
 
         _webHost.Start();


### PR DESCRIPTION
- Update MartinCostello.Testing.AwsLambdaTestServer to v0.10.0.
- Simplify `UseKestrel()` usage.
- Do not ignore `.packages`.
