### PR TITLE
Bump AwsLambdaTestServer to v0.11.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.6.0" />
-    <PackageVersion Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.10.0" />
+    <PackageVersion Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.11.0-beta.2246" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.6.0" />
-    <PackageVersion Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.11.0-beta.2246" />
+    <PackageVersion Include="MartinCostello.Testing.AwsLambdaTestServer" Version="0.11.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.8" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,9 +2,13 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="lambda-test-server" value="https://f.feedz.io/martincostello/lambda-test-server/nuget/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
+    <packageSource key="lambda-test-server">
+      <package pattern="MartinCostello.Testing.AwsLambdaTestServer" />
+    </packageSource>
     <packageSource key="NuGet">
       <package pattern="*" />
     </packageSource>

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,13 +2,9 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="lambda-test-server" value="https://f.feedz.io/martincostello/lambda-test-server/nuget/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
-    <packageSource key="lambda-test-server">
-      <package pattern="MartinCostello.Testing.AwsLambdaTestServer" />
-    </packageSource>
     <packageSource key="NuGet">
       <package pattern="*" />
     </packageSource>


### PR DESCRIPTION
Update `MartinCostello.Testing.AwsLambdaTestServer` to v0.11.0 to remove obsolete `IWebHost` usage.
