### PR TITLE
Use Enumerable.InfiniteSequence

### DIFF
--- a/src/AdventOfCode/Puzzles/Y2015/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day04.cs
@@ -40,7 +40,7 @@ public sealed class Day04 : Puzzle
         int fromInclusive = 1;
         int rangeSize = 10000;
 
-        var chunks = Enumerable.Chunk(Enumerable.Range(fromInclusive, int.MaxValue - 1), rangeSize);
+        var chunks = Enumerable.Chunk(Enumerable.InfiniteSequence(fromInclusive, 1), rangeSize);
         using var cts = new CancellationTokenSource();
 
         try

--- a/src/AdventOfCode/Puzzles/Y2016/Day25.cs
+++ b/src/AdventOfCode/Puzzles/Y2016/Day25.cs
@@ -19,11 +19,11 @@ public sealed class Day25 : Puzzle
     {
         var instructions = await ReadResourceAsLinesAsync(cancellationToken);
 
-        for (int i = 1; i < int.MaxValue; i++)
+        foreach (int i in Enumerable.InfiniteSequence(1, 1))
         {
             bool isRepeating = false;
+            bool lastSignal = true;
 
-            int lastSignal = 1;
             int iterations = 0;
 
             bool Signal(int p)
@@ -31,19 +31,10 @@ public sealed class Day25 : Puzzle
                 // If the signal is not 0 or 1, then not of interest
                 bool stop = true;
 
-                if (p == 0)
-                {
-                    if (lastSignal == 1)
-                    {
-                        // Alternation continues
-                        lastSignal = 0;
-                        stop = false;
-                    }
-                }
-                else if (p == 1 && lastSignal == 0)
+                if ((p == 0 && lastSignal) || (p == 1 && !lastSignal))
                 {
                     // Alternation continues
-                    lastSignal = 1;
+                    lastSignal = !lastSignal;
                     stop = false;
                 }
 

--- a/src/AdventOfCode/Puzzles/Y2020/Day25.cs
+++ b/src/AdventOfCode/Puzzles/Y2020/Day25.cs
@@ -39,7 +39,7 @@ public sealed class Day25 : Puzzle
         {
             long value = 1;
 
-            for (int i = 1; i < int.MaxValue; i++)
+            foreach (int i in Enumerable.InfiniteSequence(1, 1))
             {
                 value = Transform(value, subjectNumber: 7);
 


### PR DESCRIPTION
- Use `Enumerable.InfiniteSequence()` instead of for loops with a MaxValue upper bound.
- Use a `bool` to simplify some code.
