### PR TITLE
Allow npm audit fix to continue on error

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Apply audit fixes
         run: npm audit fix
+        continue-on-error: true
         working-directory: ./src/AdventOfCode.Site
 
       - name: Push changes to GitHub


### PR DESCRIPTION
Set `continue-on-error: true` so that if non-fixable vulnerabilities are found, the workflow still continues to commit any non-breaking vulnerabilities that were fixed.
