### PR TITLE
Refactor deployment pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -328,7 +328,7 @@ jobs:
 
   deploy-aws:
     if: github.event.repository.fork == false && github.ref_name == github.event.repository.default_branch
-    needs: [ build, typescript ]
+    needs: [ build, typescript, test-production ]
     runs-on: ubuntu-24.04
     concurrency: aws_environment
 


### PR DESCRIPTION
Deploy to AWS after Azure rather than in parallel.

This avoids the issue where eventual consistency means that costellobot can't approve a deployment to both environments at the same time.