### PR TITLE
Improve 2015 day 4 performance

### DIFF
--- a/src/AdventOfCode/Puzzles/Y2015/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day04.cs
@@ -45,6 +45,12 @@ public sealed class Day04 : Puzzle<int, int>
                 },
                 (offset, state, local) =>
                 {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        state.Stop();
+                        return local;
+                    }
+
                     int value = start + offset;
 
                     if (IsSolution(local.Hash, local.Buffer, keyBytes.Length, value, zeroes))

--- a/src/AdventOfCode/Puzzles/Y2015/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day04.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Buffers.Text;
-using System.Collections.Concurrent;
 using System.Security.Cryptography;
 
 namespace MartinCostello.AdventOfCode.Puzzles.Y2015;
@@ -10,7 +9,7 @@ namespace MartinCostello.AdventOfCode.Puzzles.Y2015;
 /// <summary>
 /// A class representing the puzzle for <c>https://adventofcode.com/2015/day/4</c>. This class cannot be inherited.
 /// </summary>
-[Puzzle(2015, 04, "The Ideal Stocking Stuffer", MinimumArguments = 1, IsSlow = true)]
+[Puzzle(2015, 04, "The Ideal Stocking Stuffer", MinimumArguments = 1)]
 public sealed class Day04 : Puzzle<int, int>
 {
     /// <summary>
@@ -25,29 +24,53 @@ public sealed class Day04 : Puzzle<int, int>
     /// </returns>
     public static int GetLowestPositiveNumberWithStartingZeroes(string secretKey, int zeroes, CancellationToken cancellationToken)
     {
-        int rangeSize = 5000;
-        var solutions = new ConcurrentBag<int>();
+        const int BatchSize = 100_000;
+        const int MaxValueLength = 11;
 
         byte[] keyBytes = Encoding.UTF8.GetBytes(secretKey);
+        int answer = -1;
 
-        for (int i = 0; !cancellationToken.IsCancellationRequested; i += rangeSize)
+        for (int i = 1; answer is -1 && !cancellationToken.IsCancellationRequested; i += BatchSize)
         {
-            Parallel.For(i, i + rangeSize, (j, state) =>
-            {
-                if (IsSolution(j, keyBytes, zeroes))
-                {
-                    solutions.Add(j);
-                    return;
-                }
-            });
+            int start = i;
 
-            if (!solutions.IsEmpty)
-            {
-                return solutions.Min();
-            }
+            Parallel.For(
+                0,
+                BatchSize,
+                () =>
+                {
+                    byte[] buffer = new byte[keyBytes.Length + MaxValueLength];
+                    keyBytes.CopyTo(buffer, 0);
+                    return (Hash: MD5.Create(), Buffer: buffer);
+                },
+                (offset, state, local) =>
+                {
+                    int value = start + offset;
+
+                    if (IsSolution(local.Hash, local.Buffer, keyBytes.Length, value, zeroes))
+                    {
+                        int current;
+
+                        do
+                        {
+                            current = Volatile.Read(ref answer);
+
+                            if (current is not -1 && current <= value)
+                            {
+                                break;
+                            }
+                        }
+                        while (Interlocked.CompareExchange(ref answer, value, current) != current);
+
+                        state.Break();
+                    }
+
+                    return local;
+                },
+                (local) => local.Hash.Dispose());
         }
 
-        throw new PuzzleException("No answer was found for the specified secret key.");
+        return answer is not -1 ? answer : throw new PuzzleException("No answer was found for the specified secret key.");
     }
 
     /// <inheritdoc />
@@ -74,29 +97,25 @@ public sealed class Day04 : Puzzle<int, int>
     /// <summary>
     /// Returns whether the specified integer is a solution for the specified secret key and number of zeroes.
     /// </summary>
+    /// <param name="hash">The <see cref="MD5"/> instance to use to compute the hash.</param>
+    /// <param name="buffer">The buffer containing the secret key, with room after it for the value.</param>
+    /// <param name="keyLength">The length, in bytes, of the secret key at the start of <paramref name="buffer"/>.</param>
     /// <param name="value">The value to test.</param>
-    /// <param name="secretKey">The secret key to use.</param>
     /// <param name="zeroes">The number of zeroes to get the value for.</param>
     /// <returns>
     /// <see langword="true"/> if <paramref name="value"/> is a solution; otherwise <see langword="false"/>.
     /// </returns>
-    private static bool IsSolution(int value, ReadOnlySpan<byte> secretKey, int zeroes)
+    private static bool IsSolution(MD5 hash, byte[] buffer, int keyLength, int value, int zeroes)
     {
-        const int MaxValueLength = 11;
-        int bufferLength = secretKey.Length + MaxValueLength;
+        _ = Utf8Formatter.TryFormat(value, buffer.AsSpan(keyLength), out int written);
 
-        Span<byte> buffer = bufferLength < 256 ? stackalloc byte[bufferLength] : new byte[bufferLength];
-        secretKey.CopyTo(buffer);
-
-        _ = Utf8Formatter.TryFormat(value, buffer[secretKey.Length..], out int written);
-
-        Span<byte> hash = stackalloc byte[MD5.HashSizeInBytes];
-        MD5.HashData(buffer[..(secretKey.Length + written)], hash);
+        Span<byte> hashBytes = stackalloc byte[MD5.HashSizeInBytes];
+        _ = hash.TryComputeHash(buffer.AsSpan(0, keyLength + written), hashBytes, out _);
 
         (int wholeBytes, int remainder) = Math.DivRem(zeroes, 2);
 
         // Are the whole bytes all zero?
-        foreach (byte b in hash[..wholeBytes])
+        foreach (byte b in hashBytes[..wholeBytes])
         {
             if (b is not 0)
             {
@@ -106,6 +125,6 @@ public sealed class Day04 : Puzzle<int, int>
 
         // The current value is a solution if there is an even number
         // of zeroes or if the low bits of the odd byte are zero.
-        return remainder is not 1 || hash[wholeBytes] < 0x10;
+        return remainder is not 1 || hashBytes[wholeBytes] < 0x10;
     }
 }

--- a/src/AdventOfCode/Puzzles/Y2015/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day04.cs
@@ -90,12 +90,13 @@ public sealed class Day04 : Puzzle<int, int>
 
         _ = Utf8Formatter.TryFormat(value, buffer[secretKey.Length..], out int written);
 
-        byte[] hash = MD5.HashData(buffer[..(secretKey.Length + written)]);
+        Span<byte> hash = stackalloc byte[MD5.HashSizeInBytes];
+        MD5.HashData(buffer[..(secretKey.Length + written)], hash);
 
         (int wholeBytes, int remainder) = Math.DivRem(zeroes, 2);
 
         // Are the whole bytes all zero?
-        foreach (byte b in hash.AsSpan(0, wholeBytes))
+        foreach (byte b in hash[..wholeBytes])
         {
             if (b is not 0)
             {

--- a/src/AdventOfCode/Puzzles/Y2015/Day04.cs
+++ b/src/AdventOfCode/Puzzles/Y2015/Day04.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Buffers.Text;
 using System.Collections.Concurrent;
 using System.Security.Cryptography;
 
@@ -27,11 +28,13 @@ public sealed class Day04 : Puzzle<int, int>
         int rangeSize = 5000;
         var solutions = new ConcurrentBag<int>();
 
+        byte[] keyBytes = Encoding.UTF8.GetBytes(secretKey);
+
         for (int i = 0; !cancellationToken.IsCancellationRequested; i += rangeSize)
         {
             Parallel.For(i, i + rangeSize, (j, state) =>
             {
-                if (IsSolution(j, secretKey, zeroes))
+                if (IsSolution(j, keyBytes, zeroes))
                 {
                     solutions.Add(j);
                     return;
@@ -77,11 +80,17 @@ public sealed class Day04 : Puzzle<int, int>
     /// <returns>
     /// <see langword="true"/> if <paramref name="value"/> is a solution; otherwise <see langword="false"/>.
     /// </returns>
-    private static bool IsSolution(int value, string secretKey, int zeroes)
+    private static bool IsSolution(int value, ReadOnlySpan<byte> secretKey, int zeroes)
     {
-        string formatted = secretKey + value.ToString(CultureInfo.InvariantCulture);
-        byte[] buffer = Encoding.UTF8.GetBytes(formatted);
-        byte[] hash = MD5.HashData(buffer);
+        const int MaxValueLength = 11;
+        int bufferLength = secretKey.Length + MaxValueLength;
+
+        Span<byte> buffer = bufferLength < 256 ? stackalloc byte[bufferLength] : new byte[bufferLength];
+        secretKey.CopyTo(buffer);
+
+        _ = Utf8Formatter.TryFormat(value, buffer[secretKey.Length..], out int written);
+
+        byte[] hash = MD5.HashData(buffer[..(secretKey.Length + written)]);
 
         (int wholeBytes, int remainder) = Math.DivRem(zeroes, 2);
 


### PR DESCRIPTION
- Convert the secret key to bytes once.
- Format value directly to UTF8 bytes.
- Use `stackalloc` for intermediate buffers.
- Refactor parallel computation to terminate faster and use better range sizes.
